### PR TITLE
WIP: 64bit long double tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ BINUTILS_BRANCH=${BINUTILS_BRANCH:-woarm64}
 BINUTILS_VERSION=binutils-master
 
 GCC_REPO=https://github.com/ZacWalk/gcc-woarm64.git
-GCC_BRANCH=${GCC_BRANCH:-woarm64}
+GCC_BRANCH=${GCC_BRANCH:-long-double-64}
 # GCC_VERSION=gcc-12.2.0
 GCC_VERSION=gcc-master
 
@@ -32,7 +32,7 @@ MSYS2_CONFIG=1
 TARGET=$TARGET_ARCH-w64-mingw32
 # TARGET=$TARGET_ARCH-pc-cygwin
 BUILD_DIR=build-$TARGET
-PARALLEL_MAKE=-j6
+PARALLEL_MAKE=-j$(nproc)
 MPFR_VERSION=mpfr-4.1.0
 GMP_VERSION=gmp-6.2.1
 MPC_VERSION=mpc-1.2.1
@@ -172,7 +172,7 @@ build_mingw_headers()
 {
     echo "==== build mingw headers"
     cd $BUILD_DIR/mingw-headers
-    make
+    make $PARALLEL_MAKE
     make install
     cd ../..
     # Symlink for gcc
@@ -227,7 +227,7 @@ build_mingw_libs()
 {
     echo "==== build mingw libs"
     cd $BUILD_DIR/mingw
-    make
+    make $PARALLEL_MAKE
     make install
     cd ../..
 }

--- a/tests/build-tests.sh
+++ b/tests/build-tests.sh
@@ -1,22 +1,21 @@
-rm *.s *.dump *.gkd *.exe *.dll *.log
+rm -f *.s *.dump *.gkd *.exe *.dll *.log
 
 ~/cross/bin/aarch64-w64-mingw32-g++ -S test-bigdata.cpp -o test-bigdata.s -fdump-final-insns
 ~/cross/bin/aarch64-w64-mingw32-g++ -S test-throw.cpp -o test-throw.s -fdump-final-insns
-~/cross/bin/aarch64-w64-mingw32-g++ -S test-iostream.cpp -o test-iostream.cpp.s -fdump-final-insns
+~/cross/bin/aarch64-w64-mingw32-g++ -S test-iostream.cpp -o test-iostream.s -fdump-final-insns
 ~/cross/bin/aarch64-w64-mingw32-gcc -S test-math.c -o test-math.c.s -fdump-final-insns
-~/cross/bin/aarch64-w64-mingw32-gcc -S test-pdata.c -o test-pdata.s -fdump-final-insns
-~/cross/bin/aarch64-w64-mingw32-gcc -S test-struct.c -o test-struct.s -fdump-final-insns
+~/cross/bin/aarch64-w64-mingw32-gcc -S test-pdata.c -o test-pdata.c.s -fdump-final-insns
+~/cross/bin/aarch64-w64-mingw32-gcc -S test-struct.c -o test-struct.c.s -fdump-final-insns
 
 ~/cross/bin/aarch64-w64-mingw32-g++ -g test-bigdata.cpp -o test-bigdata.exe >> test-bigdata.log
 ~/cross/bin/aarch64-w64-mingw32-g++ -g test-throw.cpp -o test-throw.exe >> test-throw.log
 ~/cross/bin/aarch64-w64-mingw32-g++ -g test-iostream.cpp -o test-iostream.exe >> test-iostream.log
 ~/cross/bin/aarch64-w64-mingw32-gcc -g test-math.c -o test-math.c.exe >> test-math.c.log
-~/cross/bin/aarch64-w64-mingw32-gcc -g test-pdata.c -ldbghelp -o test-pdata.exe >> test-pdata.log
-~/cross/bin/aarch64-w64-mingw32-gcc -g test-struct.c -o test-struct.exe >> test-struct.log
-~/cross/bin/aarch64-w64-mingw32-gcc -g test-math.c -o test-math.exe >> test-math.log
-~/cross/bin/aarch64-w64-mingw32-gcc -g test-varargs.c -o test-varargs.exe >> test-varargs.log
-~/cross/bin/aarch64-w64-mingw32-gcc -g test-sjlj.c -o test-sjlj.exe >> test-sjlj.log
-~/cross/bin/aarch64-w64-mingw32-gcc -g -fopenmp test-omp.c -o test-omp.exe >> test-omp.log
+~/cross/bin/aarch64-w64-mingw32-gcc -g test-pdata.c -ldbghelp -o test-pdata.c.exe >> test-pdata.c.log
+~/cross/bin/aarch64-w64-mingw32-gcc -g test-struct.c -o test-struct.c.exe >> test-struct.c.log
+~/cross/bin/aarch64-w64-mingw32-gcc -g test-varargs.c -o test-varargs.c.exe >> test-varargs.c.log
+~/cross/bin/aarch64-w64-mingw32-gcc -g test-sjlj.c -o test-sjlj.c.exe >> test-sjlj.c.log
+~/cross/bin/aarch64-w64-mingw32-gcc -g -fopenmp test-omp.c -o test-omp.c.exe >> test-omp.c.log
 
 #
 # DLL examples 
@@ -38,6 +37,6 @@ rm *.s *.dump *.gkd *.exe *.dll *.log
 ~/cross/bin/aarch64-w64-mingw32-objdump -dr test-throw.exe >> test-throw.dump
 ~/cross/bin/aarch64-w64-mingw32-objdump -dr test-dll-auto.exe >> test-dll-auto.dump
 ~/cross/bin/aarch64-w64-mingw32-objdump -dr test-dll-export.exe >> test-dll-export.dump
-~/cross/bin/aarch64-w64-mingw32-objdump -dr test-struct.exe >> test-struct.dump
+~/cross/bin/aarch64-w64-mingw32-objdump -dr test-struct.c.exe >> test-struct.c.dump
 
 

--- a/tests/test-math.c
+++ b/tests/test-math.c
@@ -1,38 +1,117 @@
+#include <assert.h>
+#include <stdarg.h>
 #include <stdio.h>
+#include <string.h>
 
-_Float128 foo (_Float128 x)
+// Sources:
+// - https://cpufun.substack.com/p/portable-support-for-128b-floats
+// - https://cplusplus.com/reference/cstdio/printf/
+
+#define M_E_LD 2.718281828459045235360287471352662498L
+
+#define assert_sizeof(type, size) \
+    printf ("expected: sizeof(%s) == %d\n", #type, size); \
+    printf ("actual: sizeof(%s) == %d\n", #type, sizeof (type)); \
+    assert (sizeof (type) == size);
+
+void assert_snprintf(const char* expected, const char* format, ...)
 {
-    _Complex _Float128 z1, z2;
+    va_list list;
+    va_start (list, format);
 
-    z1 = x;
-    z2 = x / 7.F128;
-    z2 /= z1;
+    const int SIZE = 1024;
+    char actual[SIZE];
+    snprintf (actual, SIZE, format, list);
+    printf ("expected: %s\n", expected);
+    printf ("actual: %s\n", actual);
+    assert (strncmp (expected, actual, SIZE) == 0);
 
-    return (_Float128) z2;
+    va_end(list);
 }
 
-_Float128 bar (_Float128 x)
+int main()
 {
-    return x * __builtin_huge_valf128 ();
-}
+    assert_sizeof (float, 4);
+    assert_sizeof (double, 8);
+    assert_sizeof (long double, 8);
 
-_Float128 baz (_Float128 x)
-{
-    return x * __builtin_huge_valf128 ();
-}
+    float f = 1.23456f;
+    double d = 1.23456;
+    long double ld = M_E_LD;
 
+    assert_snprintf ("float %f => 1.234560", "float %%f => %f", f);
+    assert_snprintf ("float %F => 1.234560", "float %%F => %F", f);
+    assert_snprintf ("float %e => 1.234560e+00", "float %%e => %e", f);
+    assert_snprintf ("float %E => 1.234560E+00", "float %%E => %E", f);
+    assert_snprintf ("float %g => 1.23456", "float %%g => %g", f);
+    assert_snprintf ("float %G => 1.23456", "float %%G => %G", f);
+    assert_snprintf ("float %a => 0x1.3c0c2p+0", "float %%a => %a", f);
+    assert_snprintf ("float %A => 0X1.3C0C2P+0", "float %%A => %A", f);
 
-int main() 
-{
-    foo (1.2Q);
-    bar (1.2Q);
-    foo (1.2F128);
-    bar (1.2F128);
-    baz (1.2F128);
-    foo (1.2Q);
-    bar (1.2Q);
-    baz (1.2Q);
+    assert_snprintf ("double %f => 1.234560", "double %%f => %f", d);
+    assert_snprintf ("double %F => 1.234560", "double %%F => %F", d);
+    assert_snprintf ("double %e => 1.234560e+00", "double %%e => %e", d);
+    assert_snprintf ("double %E => 1.234560E+00", "double %%E => %E", d);
+    assert_snprintf ("double %g => 1.23456", "double %%g => %g", d);
+    assert_snprintf ("double %G => 1.23456", "double %%G => %G", d);
+    assert_snprintf ("double %a => 0x1.3c0c1fc8f3238p+0", "double %%a => %a", d);
+    assert_snprintf ("double %A => 0X1.3C0C1FC8F3238P+0", "double %%A => %A", d);
 
-   printf("ok\n");
-   return 0;
+    assert_snprintf ("long double %f => 2.718282", "long double %%f => %f", ld);
+    assert_snprintf ("long double %F => 2.718282", "long double %%F => %F", ld);
+    assert_snprintf ("long double %e => 2.718282e+00", "long double %%e => %e", ld);
+    assert_snprintf ("long double %E => 2.718282E+00", "long double %%E => %E", ld);
+    assert_snprintf ("long double %g => 2.71828", "long double %%g => %g", ld);
+    assert_snprintf ("long double %G => 2.71828", "long double %%G => %G", ld);
+    assert_snprintf ("long double %a => 0x1.5bf0a8b145769p+1", "long double %%a => %a", ld);
+    assert_snprintf ("long double %A => 0X1.5BF0A8B145769P+1", "long double %%A => %A", ld);
+
+    assert_snprintf ("long double %Lf => 2.718282", "long double %%Lf => %Lf", ld);
+    assert_snprintf ("long double %LF => 2.718282", "long double %%LF => %LF", ld);
+    assert_snprintf ("long double %Le => 2.718282e+00", "long double %%Le => %Le", ld);
+    assert_snprintf ("long double %LE => 2.718282E+00", "long double %%LE => %LE", ld);
+    assert_snprintf ("long double %Lg => 2.71828", "long double %%Lg => %Lg", ld);
+    assert_snprintf ("long double %LG => 2.71828", "long double %%LG => %LG", ld);
+    assert_snprintf ("long double %La => 0x1.5bf0a8b145769p+1", "long double %%La => %La", ld);
+    assert_snprintf ("long double %LA => 0X1.5BF0A8B145769P+1", "long double %%LA => %LA", ld);
+
+    assert_snprintf ("long double %lf => 2.718282", "long double %%lf => %lf", ld);
+    assert_snprintf ("long double %lF => 2.718282", "long double %%lF => %lF", ld);
+    assert_snprintf ("long double %le => 2.718282e+00", "long double %%le => %le", ld);
+    assert_snprintf ("long double %lE => 2.718282E+00", "long double %%lE => %lE", ld);
+    assert_snprintf ("long double %lg => 2.71828", "long double %%lg => %lg", ld);
+    assert_snprintf ("long double %lG => 2.71828", "long double %%lG => %lG", ld);
+    assert_snprintf ("long double %la => 0x1.5bf0a8b145769p+1", "long double %%la => %la", ld);
+    assert_snprintf ("long double %lA => 0X1.5BF0A8B145769P+1", "long double %%lA => %lA", ld);
+
+    assert_snprintf ("long double %llf => 2.718282", "long double %%llf => %llf", ld);
+    assert_snprintf ("long double %llF => 2.718282", "long double %%llF => %llF", ld);
+    assert_snprintf ("long double %lle => 2.718282e+00", "long double %%lle => %lle", ld);
+    assert_snprintf ("long double %llE => 2.718282E+00", "long double %%llE => %llE", ld);
+    assert_snprintf ("long double %llg => 2.71828", "long double %%llg => %llg", ld);
+    assert_snprintf ("long double %llG => 2.71828", "long double %%llG => %llG", ld);
+    assert_snprintf ("long double %lla => 0x1.5bf0a8b145769p+1", "long double %%lla => %lla", ld);
+    assert_snprintf ("long double %llA => 0X1.5BF0A8B145769P+1", "long double %%llA => %llA", ld);
+
+    assert_snprintf ("long double %Qf => 2.718282", "long double %%Qf => %Qf", ld);
+    assert_snprintf ("long double %QF => 2.718282", "long double %%QF => %QF", ld);
+    assert_snprintf ("long double %Qe => 2.718282e+00", "long double %%Qe => %Qe", ld);
+    assert_snprintf ("long double %QE => 2.718282E+00", "long double %%QE => %QE", ld);
+    assert_snprintf ("long double %Qg => 2.71828", "long double %%Qg => %Qg", ld);
+    assert_snprintf ("long double %QG => 2.71828", "long double %%QG => %QG", ld);
+    assert_snprintf ("long double %Qa => 0x1.5bf0a8b145769p+1", "long double %%Qa => %Qa", ld);
+    assert_snprintf ("long double %QA => 0X1.5BF0A8B145769P+1", "long double %%QA => %QA", ld);
+
+    assert_snprintf ("long double %qf => 2.718282", "long double %%qf => %qf", ld);
+    assert_snprintf ("long double %qF => 2.718282", "long double %%qF => %qF", ld);
+    assert_snprintf ("long double %qe => 2.718282e+00", "long double %%qe => %qe", ld);
+    assert_snprintf ("long double %qE => 2.718282E+00", "long double %%qE => %qE", ld);
+    assert_snprintf ("long double %qg => 2.71828", "long double %%qg => %qg", ld);
+    assert_snprintf ("long double %qG => 2.71828", "long double %%qG => %qG", ld);
+    assert_snprintf ("long double %qa => 0x1.5bf0a8b145769p+1", "long double %%qa => %qa", ld);
+    assert_snprintf ("long double %qA => 0X1.5BF0A8B145769P+1", "long double %%qA => %qA", ld);
+
+    printf ("ok\n");
+
+    return 0;
 }


### PR DESCRIPTION
Tests accompanying https://github.com/ZacWalk/gcc-woarm64/pull/3. So far `%q*` and `%Q*` `printf` formats do not work, but I am not sure they actually should. Further investigation of this is ongoing.

The tests output:
```
expected: sizeof(float) == 4
actual: sizeof(float) == 4
expected: sizeof(double) == 8
actual: sizeof(double) == 8
expected: sizeof(long double) == 8
actual: sizeof(long double) == 8
expected: float %f => 1.234560
actual: float %f => 1.234560
expected: float %F => 1.234560
actual: float %F => 1.234560
expected: float %e => 1.234560e+00
actual: float %e => 1.234560e+00
expected: float %E => 1.234560E+00
actual: float %E => 1.234560E+00
expected: float %g => 1.23456
actual: float %g => 1.23456
expected: float %G => 1.23456
actual: float %G => 1.23456
expected: float %a => 0x1.3c0c2p+0
actual: float %a => 0x1.3c0c2p+0
expected: float %A => 0X1.3C0C2P+0
actual: float %A => 0X1.3C0C2P+0
expected: double %f => 1.234560
actual: double %f => 1.234560
expected: double %F => 1.234560
actual: double %F => 1.234560
expected: double %e => 1.234560e+00
actual: double %e => 1.234560e+00
expected: double %E => 1.234560E+00
actual: double %E => 1.234560E+00
expected: double %g => 1.23456
actual: double %g => 1.23456
expected: double %G => 1.23456
actual: double %G => 1.23456
expected: double %a => 0x1.3c0c1fc8f3238p+0
actual: double %a => 0x1.3c0c1fc8f3238p+0
expected: double %A => 0X1.3C0C1FC8F3238P+0
actual: double %A => 0X1.3C0C1FC8F3238P+0
expected: long double %f => 2.718282
actual: long double %f => 2.718282
expected: long double %F => 2.718282
actual: long double %F => 2.718282
expected: long double %e => 2.718282e+00
actual: long double %e => 2.718282e+00
expected: long double %E => 2.718282E+00
actual: long double %E => 2.718282E+00
expected: long double %g => 2.71828
actual: long double %g => 2.71828
expected: long double %G => 2.71828
actual: long double %G => 2.71828
expected: long double %a => 0x1.5bf0a8b145769p+1
actual: long double %a => 0x1.5bf0a8b145769p+1
expected: long double %A => 0X1.5BF0A8B145769P+1
actual: long double %A => 0X1.5BF0A8B145769P+1
expected: long double %Lf => 2.718282
actual: long double %Lf => 2.718282
expected: long double %LF => 2.718282
actual: long double %LF => 2.718282
expected: long double %Le => 2.718282e+00
actual: long double %Le => 2.718282e+00
expected: long double %LE => 2.718282E+00
actual: long double %LE => 2.718282E+00
expected: long double %Lg => 2.71828
actual: long double %Lg => 2.71828
expected: long double %LG => 2.71828
actual: long double %LG => 2.71828
expected: long double %La => 0x1.5bf0a8b145769p+1
actual: long double %La => 0x1.5bf0a8b145769p+1
expected: long double %LA => 0X1.5BF0A8B145769P+1
actual: long double %LA => 0X1.5BF0A8B145769P+1
expected: long double %lf => 2.718282
actual: long double %lf => 2.718282
expected: long double %lF => 2.718282
actual: long double %lF => 2.718282
expected: long double %le => 2.718282e+00
actual: long double %le => 2.718282e+00
expected: long double %lE => 2.718282E+00
actual: long double %lE => 2.718282E+00
expected: long double %lg => 2.71828
actual: long double %lg => 2.71828
expected: long double %lG => 2.71828
actual: long double %lG => 2.71828
expected: long double %la => 0x1.5bf0a8b145769p+1
actual: long double %la => 0x1.5bf0a8b145769p+1
expected: long double %lA => 0X1.5BF0A8B145769P+1
actual: long double %lA => 0X1.5BF0A8B145769P+1
expected: long double %llf => 2.718282
actual: long double %llf => 2.718282
expected: long double %llF => 2.718282
actual: long double %llF => 2.718282
expected: long double %lle => 2.718282e+00
actual: long double %lle => 2.718282e+00
expected: long double %llE => 2.718282E+00
actual: long double %llE => 2.718282E+00
expected: long double %llg => 2.71828
actual: long double %llg => 2.71828
expected: long double %llG => 2.71828
actual: long double %llG => 2.71828
expected: long double %lla => 0x1.5bf0a8b145769p+1
actual: long double %lla => 0x1.5bf0a8b145769p+1
expected: long double %llA => 0X1.5BF0A8B145769P+1
actual: long double %llA => 0X1.5BF0A8B145769P+1
expected: long double %Qf => 2.718282
actual: long double %Qf => %Qf
Assertion failed: strncmp (expected, actual, SIZE) == 0, file test-math.c, line 27
```