### PR TITLE
MinGW headers should be built before GCC as GCC depends on them

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -285,13 +285,13 @@ fi
 
 if [ $RUN_CONFIG = 1 ] ; then
     config_binutils
-    config_gcc_compiler
     config_mingw_headers
+    config_gcc_compiler
 fi
 
 build_binutils
-build_gcc_compiler
 build_mingw_headers
+build_gcc_compiler
 
 if [ $RUN_CONFIG = 1 ] ; then
     config_mingw_crt


### PR DESCRIPTION
MinGW headers should be built before GCC as GCC depends on them