### PR TITLE
Add workflow for automatic rebase of dependencies repositories

### DIFF
--- a/.github/scripts/build-openblas.sh
+++ b/.github/scripts/build-openblas.sh
@@ -4,7 +4,7 @@ source `dirname $0`/config.sh
 
 echo "::group::Build OpenBLAS"
     cd $SOURCE_PATH/$OPENBLAS_VERSION
-    make BINARY=64 CC=aarch64-w64-mingw32-gcc HOSTCC=gcc NOFORTRAN=1 TARGET=ARMV8 $BUILD_MAKE_OPTIONS
+    make BINARY=64 CC=aarch64-w64-mingw32-gcc CFLAGS=-Wno-incompatible-pointer-types HOSTCC=gcc NOFORTRAN=1 TARGET=ARMV8 $BUILD_MAKE_OPTIONS
     for i in ctest/x*; do 
         mv $i $i.exe
     done

--- a/.github/scripts/rebase-finish.sh
+++ b/.github/scripts/rebase-finish.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+source `dirname $0`/config.sh
+
+REBASE_BRANCH=$1
+ORIGIN_BRANCH=$2
+
+git fetch --all --prune
+
+# Check if $REBASE_BRANCH exists.
+if ! git show-ref --verify --quiet refs/remotes/origin/$REBASE_BRANCH; then
+  echo "$REBASE_BRANCH does not exist!"
+  exit 1
+fi
+
+git switch $ORIGIN_BRANCH
+git reset --hard origin/$REBASE_BRANCH
+
+git config user.name github-actions
+git config user.email github-actions@github.com
+
+TAG=$(date +%Y-%m-%d)-$(git log -n 1 --pretty=format:"%h" origin/$ORIGIN_BRANCH)
+
+# Create origin/$ORIGIN_BRANCH backup.
+git branch $ORIGIN_BRANCH-$TAG origin/$ORIGIN_BRANCH
+git push --set-upstream origin $ORIGIN_BRANCH-$TAG
+
+# Overwrite origin/$REBASE_BRANCH.
+git push --force-with-lease --set-upstream origin $ORIGIN_BRANCH
+git push origin -d $REBASE_BRANCH
+
+echo 'Success!'

--- a/.github/scripts/rebase-start.sh
+++ b/.github/scripts/rebase-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+source `dirname $0`/config.sh
+
+UPSTREAM_URL=$1 
+UPSTREAM_BRANCH=$2
+REBASE_BRANCH=$3
+
+# Add and update upstream remote.
+if ! git remote | grep upstream; then
+    git remote add upstream $UPSTREAM_URL
+fi
+
+git fetch --all --prune
+
+# Checkout or create $REBASE_BRANCH.
+if git show-ref --verify --quiet refs/remotes/origin/$REBASE_BRANCH; then
+    git switch $REBASE_BRANCH
+    git pull origin $REBASE_BRANCH
+else
+    git switch -c $REBASE_BRANCH
+fi
+
+git config user.name github-actions
+git config user.email github-actions@github.com
+
+# Create upstream branch from upstream/$UPSTREAM_BRANCH.
+git branch upstream upstream/$UPSTREAM_BRANCH
+git push --set-upstream origin upstream
+
+# Rebase $REBASE_BRANCH on upstream/$UPSTREAM_BRANCH.
+git rebase upstream/$UPSTREAM_BRANCH
+git push --force-with-lease --set-upstream origin $REBASE_BRANCH
+
+echo 'Success!'

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -27,22 +27,30 @@ on:
         description: 'OpenSSL branch to test'
         required: false
         default: 'fix-tests'
+  workflow_call:
+    inputs:
+      binutils_branch:
+        type: string
+      gcc_branch:
+        type: string
+      mingw_branch:
+        type: string
 
 env:
   BINUTILS_REPO: Windows-on-ARM-Experiments/binutils-woarm64
-  BINUTILS_BRANCH: ${{ github.event.inputs.binutils_branch || 'woarm64' }}
+  BINUTILS_BRANCH: ${{ inputs.binutils_branch || 'woarm64' }}
   BINUTILS_VERSION: binutils-master
 
   GCC_REPO: Windows-on-ARM-Experiments/gcc-woarm64
-  GCC_BRANCH: ${{ github.event.inputs.gcc_branch || 'woarm64' }}
+  GCC_BRANCH: ${{ inputs.gcc_branch || 'woarm64' }}
   GCC_VERSION: gcc-master
 
   MINGW_REPO: Windows-on-ARM-Experiments/mingw-woarm64
-  MINGW_BRANCH: ${{ github.event.inputs.mingw_branch || 'woarm64' }}
+  MINGW_BRANCH: ${{ inputs.mingw_branch || 'woarm64' }}
   MINGW_VERSION: mingw-w64-master
 
   OPENBLAS_REPO: OpenMathLib/OpenBLAS.git
-  OPENBLAS_BRANCH: ${{ github.event.inputs.openblas_branch || 'develop' }}
+  OPENBLAS_BRANCH: ${{ inputs.openblas_branch || 'develop' }}
   OPENBLAS_VERSION: openblas-develop
 
   ZLIB_REPO: madler/zlib
@@ -50,7 +58,7 @@ env:
   ZLIB_VERSION: zlib-develop
 
   OPENSSL_REPO: Windows-on-ARM-Experiments/openssl
-  OPENSSL_BRANCH: ${{ github.event.inputs.openssl_branch || 'fix-tests' }}
+  OPENSSL_BRANCH: ${{ inputs.openssl_branch || 'fix-tests' }}
   OPENSSL_VERSION: openssl-master
 
   LIBJPEG_TURBO_REPO: libjpeg-turbo/libjpeg-turbo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ on:
         required: false
         default: 'woarm64'
 env:
-  BINUTILS_BRANCH: ${{ github.event.inputs.binutils_branch }}
-  GCC_BRANCH: ${{ github.event.inputs.gcc_branch }}
-  MINGW_BRANCH: ${{ github.event.inputs.mingw_branch }}
+  BINUTILS_BRANCH: ${{ inputs.binutils_branch }}
+  GCC_BRANCH: ${{ inputs.gcc_branch }}
+  MINGW_BRANCH: ${{ inputs.mingw_branch }}
 
 jobs:
   run-script:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,179 @@
+name: Daily rebase
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      origin_branch:
+        description: 'Origin branch'
+        required: true
+        default: 'woarm64'
+      upstream_branch:
+        description: 'Upstream branch'
+        required: true
+        default: 'master'
+      rebase_branch:
+        description: 'Rebase branch'
+        required: true
+        default: 'rebase-upstream'
+
+permissions:
+  repository-projects: write
+
+env:
+  BINUTILS_REPO: Windows-on-ARM-Experiments/binutils-woarm64
+  BINUTILS_UPSTREAM_URL: git://sourceware.org/git/binutils-gdb.git
+  GCC_REPO: Windows-on-ARM-Experiments/gcc-woarm64
+  GCC_UPSTREAM_URL: git://gcc.gnu.org/git/gcc.git
+  MINGW_REPO: Windows-on-ARM-Experiments/mingw-woarm64
+  MINGW_UPSTREAM_URL: https://git.code.sf.net/p/mingw-w64/mingw-w64
+
+  SOURCE_PATH: ${{ github.workspace }}/code
+  ORIGIN_BRANCH: ${{ inputs.origin_branch || 'woarm64' }}
+  UPSTREAM_BRANCH: ${{ inputs.upstream_branch || 'master' }}
+  REBASE_BRANCH: ${{ inputs.rebase_branch || 'rebase-upstream' }}
+
+jobs:
+  start-binutils-rebase:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}
+
+      - name: Checkout binutils
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GNU_PUSH_PAT }}
+          repository: ${{ env.BINUTILS_REPO }}
+          ref: ${{ env.ORIGIN_BRANCH }}
+          path: ${{ env.SOURCE_PATH }}/binutils
+
+      - name: Start binutils rebase
+        working-directory: ${{ env.SOURCE_PATH }}/binutils
+        run: |
+          ${{ github.workspace }}/.github/scripts/rebase-start.sh ${{ env.BINUTILS_UPSTREAM_URL }} ${{ env.UPSTREAM_BRANCH }} ${{ env.REBASE_BRANCH }}
+
+  start-gcc-rebase:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}
+
+      - name: Checkout GCC
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GNU_PUSH_PAT }}
+          repository: ${{ env.GCC_REPO }}
+          ref: ${{ env.ORIGIN_BRANCH }}
+          path: ${{ env.SOURCE_PATH }}/gcc
+
+      - name: Start GCC rebase
+        working-directory: ${{ env.SOURCE_PATH }}/gcc
+        run: |
+          ${{ github.workspace }}/.github/scripts/rebase-start.sh ${{ env.GCC_UPSTREAM_URL }} ${{ env.UPSTREAM_BRANCH }} ${{ env.REBASE_BRANCH }}
+
+  start-mingw-rebase:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}
+
+      - name: Checkout MinGW
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GNU_PUSH_PAT }}
+          repository: ${{ env.MINGW_REPO }}
+          ref: ${{ env.ORIGIN_BRANCH }}
+          path: ${{ env.SOURCE_PATH }}/mingw
+
+      - name: Start MinGW rebase
+        working-directory: ${{ env.SOURCE_PATH }}/mingw
+        run: |
+          ${{ github.workspace }}/.github/scripts/rebase-start.sh ${{ env.MINGW_UPSTREAM_URL }} ${{ env.UPSTREAM_BRANCH }} ${{ env.REBASE_BRANCH }}
+
+  build:
+    needs: [start-binutils-rebase, start-gcc-rebase, start-mingw-rebase]
+    uses: ./.github/workflows/advanced.yml
+    with:
+      binutils_branch: ${{ inputs.rebase_branch || 'rebase-upstream' }}
+      gcc_branch: ${{ inputs.rebase_branch || 'rebase-upstream' }}
+      mingw_branch: ${{ inputs.rebase_branch || 'rebase-upstream' }}
+
+  finish-binutils-rebase:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}
+
+      - name: Checkout binutils
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GNU_PUSH_PAT }}
+          repository: ${{ env.BINUTILS_REPO }}
+          ref: ${{ env.ORIGIN_BRANCH }}
+          path: ${{ env.SOURCE_PATH }}/binutils
+
+      - name: Finish binutils rebase
+        working-directory: ${{ env.SOURCE_PATH }}/binutils
+        run: |
+          ${{ github.workspace }}/.github/scripts/rebase-finish.sh ${{ env.REBASE_BRANCH }} ${{ env.ORIGIN_BRANCH }}
+
+  finish-gcc-rebase:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}
+
+      - name: Checkout GCC
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GNU_PUSH_PAT }}
+          repository: ${{ env.GCC_REPO }}
+          ref: ${{ env.ORIGIN_BRANCH }}
+          path: ${{ env.SOURCE_PATH }}/gcc
+
+      - name: Finish GCC rebase
+        working-directory: ${{ env.SOURCE_PATH }}/gcc
+        run: |
+          ${{ github.workspace }}/.github/scripts/rebase-finish.sh ${{ env.REBASE_BRANCH }} ${{ env.ORIGIN_BRANCH }}
+
+  finish-mingw-rebase:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}
+
+      - name: Checkout MinGW
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GNU_PUSH_PAT }}
+          repository: ${{ env.MINGW_REPO }}
+          ref: ${{ env.ORIGIN_BRANCH }}
+          path: ${{ env.SOURCE_PATH }}/mingw
+
+      - name: Finish MinGW rebase
+        working-directory: ${{ env.SOURCE_PATH }}/mingw
+        run: |
+          ${{ github.workspace }}/.github/scripts/rebase-finish.sh ${{ env.REBASE_BRANCH }} ${{ env.ORIGIN_BRANCH }}


### PR DESCRIPTION
Attempts to rebase binutils, GCC and MinGW repositories to upstream `master` branches, then triggers the advanced worflow and if it suceeds, finishes the rebase by overwriting `woarm64` branches. If the build fails the `rebase-upstream` branches will contain the rebase results.

https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/pull/74/commits/a66d57d4c5dfedbe126e1b74e3b1d003a13dd24e commit will be removed before merge.