### PR TITLE
Skip toolchain packing for toolchains that are not needed

### DIFF
--- a/.github/scripts/pack-toolchain-mock.sh
+++ b/.github/scripts/pack-toolchain-mock.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source `dirname $0`/config.sh
+
+echo "::group::Pack toolchain mock"
+    mkdir -p $ARTIFACT_PATH
+    tar czf $ARTIFACT_PATH/$TOOLCHAIN_PACKAGE_NAME --files-from /dev/null
+echo "::endgroup::"
+
+echo 'Success!'

--- a/.github/scripts/pack-toolchain.sh
+++ b/.github/scripts/pack-toolchain.sh
@@ -3,8 +3,8 @@
 source `dirname $0`/config.sh
 
 echo "::group::Pack toolchain"
-mkdir -p $ARTIFACT_PATH
-tar czf $ARTIFACT_PATH/$TOOLCHAIN_PACKAGE_NAME -C $TOOLCHAIN_PATH .
+    mkdir -p $ARTIFACT_PATH
+    tar czf $ARTIFACT_PATH/$TOOLCHAIN_PACKAGE_NAME -C $TOOLCHAIN_PATH .
 echo "::endgroup::"
 
 echo 'Success!'

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -195,10 +195,15 @@ jobs:
           .github/scripts/build-gcc-libs.sh
 
       - name: Pack toolchain
-        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.TOOLCHAIN_NAME == 'aarch64-w64-mingw32-msvcrt' }}
         run: |
           .github/scripts/pack-toolchain.sh
 
+      - name: Pack toolchain mock
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.TOOLCHAIN_NAME != 'aarch64-w64-mingw32-msvcrt' }}
+        run: |
+          .github/scripts/pack-toolchain-mock.sh
+          
       - name: Upload artifact
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Creates empty archive for toolchain variants that won't be ever used. This still allows to leverage the caching.