### PR TITLE
Fix `patches/libjpeg-turbo/testimages.patch` after libjpeg-turbo repo update

### DIFF
--- a/patches/libjpeg-turbo/testimages.patch
+++ b/patches/libjpeg-turbo/testimages.patch
@@ -1,15 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 02709e9a..51954169 100644
+index 26bb189c..5a98161c 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -861,8 +861,8 @@ endif()
+@@ -897,7 +897,7 @@ endif()
+ 
  set(TESTIMAGES ${CMAKE_CURRENT_SOURCE_DIR}/testimages)
- set(MD5CMP ${CMAKE_CURRENT_BINARY_DIR}/md5/md5cmp)
  if(CMAKE_CROSSCOMPILING)
 -  file(RELATIVE_PATH TESTIMAGES ${CMAKE_CURRENT_BINARY_DIR} ${TESTIMAGES})
--  file(RELATIVE_PATH MD5CMP ${CMAKE_CURRENT_BINARY_DIR} ${MD5CMP})
 +  set(TESTIMAGES "testimages")
-+  set(MD5CMP "md5/md5cmp")
  endif()
  
  # The output of the floating point DCT/IDCT algorithms differs depending on the


### PR DESCRIPTION
Fixes application of libjpeg-turbo patch cause by repo update.