### PR TITLE
Use stable tag for libjpeg-turbo testing

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -66,7 +66,7 @@ env:
   OPENSSL_VERSION: openssl-master
 
   LIBJPEG_TURBO_REPO: libjpeg-turbo/libjpeg-turbo
-  LIBJPEG_TURBO_BRANCH: main
+  LIBJPEG_TURBO_BRANCH: 3.0.2
   LIBJPEG_TURBO_VERSION: libjpeg-turbo-main
 
   FFMPEG_REPO: FFmpeg/FFmpeg


### PR DESCRIPTION
Resolve the current automatic rebase workflow failure.