### PR TITLE
Add manual release step to daily updates workflow

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -35,6 +35,11 @@ on:
         type: string
       mingw_branch:
         type: string
+    outputs:
+      toolchain-package-name:
+        value: ${{ jobs.build-toolchain.outputs.toolchain-package-name }}
+      toolchain-cache-key:
+        value: ${{ jobs.build-toolchain.outputs.toolchain-cache-key }}
 
 env:
   BINUTILS_REPO: Windows-on-ARM-Experiments/binutils-woarm64
@@ -100,6 +105,7 @@ jobs:
     env:
       TARGET: ${{ matrix.arch }}-${{ matrix.platform }}
       CRT: ${{ matrix.crt }}
+      PACK_TOOLCHAIN: ${{ matrix.arch == 'aarch64' && matrix.platform == 'w64-mingw32' && matrix.crt == 'msvcrt' }}
       TOOLCHAIN_NAME: ${{ matrix.arch }}-${{ matrix.platform }}-${{ matrix.crt }}
       TOOLCHAIN_PACKAGE_NAME: ${{ matrix.arch }}-${{ matrix.platform }}-${{ matrix.crt }}-toolchain.tar.gz
       TESTS_PACKAGE_NAME: ${{ matrix.arch }}-${{ matrix.crt }}-tests.tar.gz
@@ -143,7 +149,7 @@ jobs:
 
       - name: Cache toolchain
         id: cache-toolchain
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
           key: ${{ env.TOOLCHAIN_NAME }}-${{ steps.workflow-sha.outputs.sha }}-${{ steps.binutils-sha.outputs.sha }}-${{ steps.gcc-sha.outputs.sha }}-${{ steps.mingw-sha.outputs.sha }}-${{ steps.binutils-scripts-sha.outputs.sha }}-${{ steps.toolchain-scripts-sha.outputs.sha }}
@@ -223,17 +229,17 @@ jobs:
           .github/scripts/toolchain/build-gcc-libs.sh
 
       - name: Pack toolchain
-        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.TOOLCHAIN_NAME == 'aarch64-w64-mingw32-msvcrt' }}
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.PACK_TOOLCHAIN == 'true' }}
         run: |
           .github/scripts/toolchain/pack.sh
 
       - name: Pack toolchain mock
-        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.TOOLCHAIN_NAME != 'aarch64-w64-mingw32-msvcrt' }}
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.PACK_TOOLCHAIN != 'true' }}
         run: |
           .github/scripts/toolchain/pack-mock.sh
           
       - name: Upload artifact
-        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' || env.PACK_TOOLCHAIN == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TOOLCHAIN_PACKAGE_NAME }}
@@ -241,7 +247,8 @@ jobs:
           retention-days: 3
 
     outputs:
-      toolchain-cache-key: aarch64-w64-mingw32-msvcrt-${{ steps.workflow-sha.outputs.sha }}-${{ steps.binutils-sha.outputs.sha }}-${{ steps.gcc-sha.outputs.sha }}-${{ steps.mingw-sha.outputs.sha }}-${{ steps.binutils-scripts-sha.outputs.sha }}-${{ steps.toolchain-scripts-sha.outputs.sha }}
+      toolchain-package-name: ${{ env.PACK_TOOLCHAIN == 'true' && env.TOOLCHAIN_PACKAGE_NAME || '' }}
+      toolchain-cache-key: ${{ env.PACK_TOOLCHAIN == 'true' && format('{0}-{1}-{2}-{3}-{4}-{5}-{6}', env.TOOLCHAIN_NAME, steps.workflow-sha.outputs.sha, steps.binutils-sha.outputs.sha, steps.gcc-sha.outputs.sha, steps.mingw-sha.outputs.sha, steps.binutils-scripts-sha.outputs.sha, steps.toolchain-scripts-sha.outputs.sha) || '' }}
 
   build-aarch64-tests:
     needs: [build-toolchain]
@@ -257,7 +264,7 @@ jobs:
           path: ${{ github.workspace }}
 
       - name: Download toolchain
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
           key: ${{ needs.build-toolchain.outputs.toolchain-cache-key }}
@@ -327,7 +334,7 @@ jobs:
           path: ${{ env.SOURCE_PATH }}/${{ env.OPENBLAS_VERSION }}
 
       - name: Download toolchain
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
           key: ${{ needs.build-toolchain.outputs.toolchain-cache-key }}
@@ -401,7 +408,7 @@ jobs:
           path: ${{ env.SOURCE_PATH }}/${{ env.ZLIB_VERSION }}
 
       - name: Download toolchain
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
           key: ${{ needs.build-toolchain.outputs.toolchain-cache-key }}
@@ -447,7 +454,7 @@ jobs:
           path: ${{ env.SOURCE_PATH }}/${{ env.LIBXML2_VERSION }}
 
       - name: Download toolchain
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
           key: ${{ needs.build-toolchain.outputs.toolchain-cache-key }}
@@ -508,7 +515,7 @@ jobs:
           .github/scripts/openssl/install-dependencies.sh
 
       - name: Download toolchain
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
           key: ${{ needs.build-toolchain.outputs.toolchain-cache-key }}
@@ -624,7 +631,7 @@ jobs:
           .github/scripts/libjpeg-turbo/patch.sh
 
       - name: Download toolchain
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
           key: ${{ needs.build-toolchain.outputs.toolchain-cache-key }}
@@ -709,7 +716,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download toolchain
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
           key: ${{ needs.build-toolchain.outputs.toolchain-cache-key }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   start-binutils-rebase:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -180,3 +180,32 @@ jobs:
         working-directory: ${{ env.SOURCE_PATH }}/mingw
         run: |
           ${{ github.workspace }}/.github/scripts/rebase-finish.sh ${{ env.REBASE_BRANCH }} ${{ env.ORIGIN_BRANCH }}
+
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    environment:
+      name: release
+      url: ${{steps.create-release.outputs.url }}
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.toolchain-package-name }}
+
+      - name: Create tag
+        run: |
+          echo "TAG=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
+
+      - name: Create release
+        id: create-release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ needs.build.outputs.toolchain-package-name }}
+          tag_name: ${{ env.TAG }}


### PR DESCRIPTION
This change will allow us to manually promote the result of a daily updates workflow to a release. This should help users of our toolchain to more easily access the binaries.

The workflow run demonstrating how it looks like is https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/7830612468