### PR TITLE
WIP: Make GCC configuration as similar to MSYS2 as possible

### DIFF
--- a/.github/scripts/binutils/build.sh
+++ b/.github/scripts/binutils/build.sh
@@ -12,7 +12,7 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$BINUTILS_BUILD_PATH/Makefile" ] ; then
         rm -rf $BINUTILS_BUILD_PATH/*
 
         if [ "$DEBUG" = 1 ] ; then
-            ADDITIONAL_OPTIONS=" \
+            HOST_OPTIONS="$HOST_OPTIONS \
                 --enable-debug"
         fi
 
@@ -21,7 +21,8 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$BINUTILS_BUILD_PATH/Makefile" ] ; then
             --build=$BUILD \
             --host=$HOST \
             --target=$TARGET \
-            $ADDITIONAL_OPTIONS
+            $HOST_OPTIONS \
+            $TARGET_OPTIONS
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/config-mingw.sh
+++ b/.github/scripts/config-mingw.sh
@@ -10,14 +10,19 @@ case "$ARCH" in
     ;;
     aarch64)
         TARGET_OPTIONS="$TARGET_OPTIONS --disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
+        MINGW_CFLAGS="-mno-outline-atomics"
     ;;
 esac
 
 case "$CRT" in
     ucrt)
-        TARGET_OPTIONS="$TARGET_OPTIONS --with-default-msvcrt=ucrt"
+        TARGET_OPTIONS="$TARGET_OPTIONS \
+            --with-default-msvcrt=ucrt \
+            --with-default-win32-winnt=0x603"
     ;;
     msvcrt)
-        TARGET_OPTIONS="$TARGET_OPTIONS --with-default-msvcrt=msvcrt"
+        TARGET_OPTIONS="$TARGET_OPTIONS \
+            --with-default-msvcrt=msvcrt \
+            --with-default-win32-winnt=0x601"
     ;;
 esac

--- a/.github/scripts/config-mingw.sh
+++ b/.github/scripts/config-mingw.sh
@@ -6,22 +6,18 @@ MINGW_VERSION=${MINGW_VERSION:-mingw-w64-master}
 
 case "$ARCH" in
     x86_64)
-        MINGW_CONF="$MINGW_CONF --disable-lib32 --enable-lib64 --disable-libarm32 --disable-libarm64"
+        TARGET_OPTIONS="$TARGET_OPTIONS --disable-lib32 --enable-lib64 --disable-libarm32 --disable-libarm64"
     ;;
     aarch64)
-        MINGW_CONF="$MINGW_CONF --disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
+        TARGET_OPTIONS="$TARGET_OPTIONS --disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
     ;;
 esac
 
 case "$CRT" in
     ucrt)
-        MINGW_CONF="$MINGW_CONF --with-default-msvcrt=ucrt"
+        TARGET_OPTIONS="$TARGET_OPTIONS --with-default-msvcrt=ucrt"
     ;;
     msvcrt)
-        MINGW_CONF="$MINGW_CONF --with-default-msvcrt=msvcrt"
+        TARGET_OPTIONS="$TARGET_OPTIONS --with-default-msvcrt=msvcrt"
     ;;
 esac
-
-if [ "$DEBUG" = 1 ] ; then
-    MINGW_CONF="$MINGW_CONF --enable-debug"
-fi

--- a/.github/scripts/ffmpeg/build.sh
+++ b/.github/scripts/ffmpeg/build.sh
@@ -13,7 +13,7 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$FFMPEG_BUILD_PATH/Makefile" ] ; then
         rm -rf $FFMPEG_BUILD_PATH/*
 
         if [ "$DEBUG" = 1 ] ; then
-            ADDITIONAL_OPTIONS=" \
+            HOST_OPTIONS=" \
                 --enable-debug=3"
         fi
 
@@ -25,7 +25,7 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$FFMPEG_BUILD_PATH/Makefile" ] ; then
             --arch=aarch64 \
             --target-os=mingw32 \
             --cross-prefix=aarch64-w64-mingw32- \
-            $ADDITIONAL_OPTIONS
+            $HOST_OPTIONS
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-gcc.sh
+++ b/.github/scripts/toolchain/build-gcc.sh
@@ -41,37 +41,39 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$GCC_BUILD_PATH/Makefile" ] ; then
                 ;;
         esac
 
+        # ADDED --includedir=$TOOLCHAIN_PATH/$TARGET/include
         # REMOVED --libexecdir=/opt/lib
-        # REMOVED --with-{gmp,mpfr,mpc,isl}=/usr
         $SOURCE_PATH/$GCC_VERSION/configure \
             --prefix=$TOOLCHAIN_PATH \
             --build=$BUILD \
             --host=$HOST \
             --target=$TARGET \
             --includedir=$TOOLCHAIN_PATH/$TARGET/include \
+            --libexecdir=$TOOLCHAIN_PATH/lib \
+            --disable-bootstrap \
             --enable-languages=c,lto,c++,fortran \
             --enable-shared \
             --enable-static \
             --enable-graphite \
             --enable-fully-dynamic-string \
-            --enable-libstdcxx-filesystem-ts=yes \
-            --enable-libstdcxx-time=yes \
+            --enable-libstdcxx-filesystem-ts \
+            --enable-libstdcxx-time \
+            --disable-libstdcxx-pch \
+            --disable-libstdcxx-debug \
             --enable-cloog-backend=isl \
             --enable-version-specific-runtime-libs \
+            --disable-isl-version-check \
             --enable-lto \
             --enable-libgomp \
-            --enable-checking=release \
+            --disable-libssp \
             --disable-multilib \
-            --disable-shared \
+            --enable-checking=release \
             --disable-rpath \
             --disable-werror \
             --disable-symvers \
-            --disable-libstdcxx-pch \
-            --disable-libstdcxx-debug \
-            --disable-isl-version-check \
-            --disable-bootstrap \
             --with-libiconv \
             --with-system-zlib \
+            --with-{gmp,mpfr,mpc,isl}=/usr \
             --with-gnu-as \
             --with-gnu-ld \
             $HOST_OPTIONS \

--- a/.github/scripts/toolchain/build-gcc.sh
+++ b/.github/scripts/toolchain/build-gcc.sh
@@ -11,18 +11,35 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$GCC_BUILD_PATH/Makefile" ] ; then
     echo "::group::Configure GCC"
         rm -rf $GCC_BUILD_PATH/*
 
+        if [ "$DEBUG" = 1 ] ; then
+            HOST_OPTIONS="$HOST_OPTIONS \
+                --enable-debug"
+        fi
+
+        case $ARCH in
+            x86_64)
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --with-arch=nocona \
+                    --with-tune=generic"
+                ;;
+            aarch64)
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --with-arch=armv8-a \
+                    --with-tune=cortex-a53"
+                ;;
+        esac
+
         case $PLATFORM in
+            *linux*)
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --enable-threads=posix"
+                ;;
             *mingw*)
-                HOST_OPTIONS=" \
+                TARGET_OPTIONS="$TARGET_OPTIONS \
                     --enable-threads=win32 \
                     --disable-win32-registry"
                 ;;
         esac
-
-        if [ "$DEBUG" = 1 ] ; then
-            ADDITIONAL_OPTIONS=" \
-                --enable-debug"
-        fi
 
         # REMOVED --libexecdir=/opt/lib
         # REMOVED --with-{gmp,mpfr,mpc,isl}=/usr
@@ -58,7 +75,7 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$GCC_BUILD_PATH/Makefile" ] ; then
             --with-gnu-as \
             --with-gnu-ld \
             $HOST_OPTIONS \
-            $ADDITIONAL_OPTIONS
+            $TARGET_OPTIONS
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-mingw-crt.sh
+++ b/.github/scripts/toolchain/build-mingw-crt.sh
@@ -19,7 +19,8 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$MINGW_BUILD_PATH/Makefile" ] ; then
         case $PLATFORM in
             *mingw*)
                 TARGET_OPTIONS="$TARGET_OPTIONS \
-                    --with-sysroot=$TOOLCHAIN_PATH"
+                    --enable-wildcard \
+                    --disable-dependency-tracking"
                 ;;
         esac
 
@@ -28,7 +29,8 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$MINGW_BUILD_PATH/Makefile" ] ; then
             --build=$BUILD \
             --host=$TARGET \
             $HOST_OPTIONS \
-            $TARGET_OPTIONS
+            $TARGET_OPTIONS \
+            CFLAGS="$MINGW_CFLAGS"
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-mingw-crt.sh
+++ b/.github/scripts/toolchain/build-mingw-crt.sh
@@ -2,7 +2,7 @@
 
 source `dirname ${BASH_SOURCE[0]}`/../config-mingw.sh
 
-MINGW_BUILD_PATH=$BUILD_PATH/mingw
+MINGW_BUILD_PATH=$BUILD_PATH/mingw-crt
 
 mkdir -p $MINGW_BUILD_PATH
 cd $MINGW_BUILD_PATH
@@ -11,22 +11,33 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$MINGW_BUILD_PATH/Makefile" ] ; then
     echo "::group::Configure MinGW CRT"
         rm -rf $MINGW_BUILD_PATH/*
 
+        if [ "$DEBUG" = 1 ] ; then
+            HOST_OPTIONS="$HOST_OPTIONS \
+                --enable-debug"
+        fi
+
+        case $PLATFORM in
+            *mingw*)
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --with-sysroot=$TOOLCHAIN_PATH"
+                ;;
+        esac
+
         $SOURCE_PATH/$MINGW_VERSION/mingw-w64-crt/configure \
             --prefix=$TOOLCHAIN_PATH/$TARGET \
             --build=$BUILD \
             --host=$TARGET \
-            --with-sysroot=$TOOLCHAIN_PATH \
-            --disable-shared \
-            $MINGW_CONF
+            $HOST_OPTIONS \
+            $TARGET_OPTIONS
     echo "::endgroup::"
 fi
 
-echo "::group::Build MinGW headers"
+echo "::group::Build MinGW CRT"
     make $BUILD_MAKE_OPTIONS
 echo "::endgroup::"
 
 if [ "$RUN_INSTALL" = 1 ] ; then
-    echo "::group::Install MinGW headers"
+    echo "::group::Install MinGW CRT"
         make install
     echo "::endgroup::"
 fi

--- a/.github/scripts/toolchain/build-mingw-headers.sh
+++ b/.github/scripts/toolchain/build-mingw-headers.sh
@@ -16,6 +16,13 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$MINGW_HEADERS_BUILD_PATH/Makefile" ] ; then
                 --enable-debug"
         fi
 
+        case $PLATFORM in
+            *mingw*)
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                     --enable-sdk=all"
+                ;;
+        esac
+
         $SOURCE_PATH/$MINGW_VERSION/mingw-w64-headers/configure \
             --prefix=$TOOLCHAIN_PATH/$TARGET \
             --build=$BUILD \

--- a/.github/scripts/toolchain/build-mingw-headers.sh
+++ b/.github/scripts/toolchain/build-mingw-headers.sh
@@ -11,11 +11,17 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$MINGW_HEADERS_BUILD_PATH/Makefile" ] ; then
     echo "::group::Configure MinGW headers"
         rm -rf $MINGW_HEADERS_BUILD_PATH/*
 
+        if [ "$DEBUG" = 1 ] ; then
+            HOST_OPTIONS="$HOST_OPTIONS \
+                --enable-debug"
+        fi
+
         $SOURCE_PATH/$MINGW_VERSION/mingw-w64-headers/configure \
             --prefix=$TOOLCHAIN_PATH/$TARGET \
             --build=$BUILD \
             --host=$TARGET \
-            $MINGW_CONF
+            $HOST_OPTIONS \
+            $TARGET_OPTIONS
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-mingw-winpthreads.sh
+++ b/.github/scripts/toolchain/build-mingw-winpthreads.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../config-mingw.sh
+
+MINGW_BUILD_PATH=$BUILD_PATH/mingw-winpthreads
+
+mkdir -p $MINGW_BUILD_PATH
+cd $MINGW_BUILD_PATH
+
+if [ $RUN_CONFIG = 1 ] || [ ! -f "$MINGW_BUILD_PATH/Makefile" ] ; then
+    echo "::group::Configure MinGW Winpthreads"
+
+    rm -rf $MINGW_BUILD_PATH/*
+
+    $SOURCE_PATH/$MINGW_VERSION/mingw-w64-libraries/winpthreads/configure \
+      --prefix=$TOOLCHAIN_PATH/$TARGET \
+      --build=$HOST \
+      --host=$TARGET \
+      --enable-static \
+      --enable-shared \
+      $MINGW_CONF \
+      CFLAGS="$MINGW_CFLAGS"
+    echo "::endgroup::"
+fi
+
+echo "::group::Build MinGW Winpthreads"
+make $BUILD_MAKE_OPTIONS
+echo "::endgroup::"
+
+if [ $RUN_INSTALL = 1 ] ; then
+    echo "::group::Install MinGW Winpthreads"
+    make install
+    echo "::endgroup::"
+fi
+
+echo 'Success!'

--- a/.github/scripts/toolchain/build-mingw.sh
+++ b/.github/scripts/toolchain/build-mingw.sh
@@ -19,8 +19,8 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$MINGW_BUILD_PATH/Makefile" ] ; then
         case $PLATFORM in
             *mingw*)
                 TARGET_OPTIONS="$TARGET_OPTIONS \
-                    --disable-shared \
-                    --with-libraries=libmangle,pseh,winpthreads"
+                    --enable-wildcard \
+                    --disable-dependency-tracking"
                 ;;
         esac
 

--- a/.github/scripts/toolchain/build-mingw.sh
+++ b/.github/scripts/toolchain/build-mingw.sh
@@ -11,13 +11,25 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$MINGW_BUILD_PATH/Makefile" ] ; then
     echo "::group::Configure MinGW libraries"
         rm -rf $MINGW_BUILD_PATH/*
 
+        if [ "$DEBUG" = 1 ] ; then
+            HOST_OPTIONS="$HOST_OPTIONS \
+                --enable-debug"
+        fi
+
+        case $PLATFORM in
+            *mingw*)
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --disable-shared \
+                    --with-libraries=libmangle,pseh,winpthreads"
+                ;;
+        esac
+
         $SOURCE_PATH/$MINGW_VERSION/configure \
             --prefix=$TOOLCHAIN_PATH/$TARGET \
             --build=$BUILD \
             --host=$TARGET \
-            --disable-shared \
-            --with-libraries=libmangle,pseh,winpthreads \
-            $MINGW_CONF
+            $HOST_OPTIONS \
+            $TARGET_OPTIONS
     echo "::endgroup::"
 fi
 

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -14,7 +14,7 @@ on:
       gcc_branch:
         description: 'GCC branch to build'
         required: false
-        default: 'woarm64'
+        default: 'fix-enable-shared'
       mingw_branch:
         description: 'Mingw branch to build'
         required: false
@@ -47,7 +47,7 @@ env:
   BINUTILS_VERSION: binutils-master
 
   GCC_REPO: Windows-on-ARM-Experiments/gcc-woarm64
-  GCC_BRANCH: ${{ inputs.gcc_branch || 'woarm64' }}
+  GCC_BRANCH: ${{ inputs.gcc_branch || 'fix-enable-shared' }}
   GCC_VERSION: gcc-master
 
   MINGW_REPO: Windows-on-ARM-Experiments/mingw-woarm64
@@ -222,7 +222,7 @@ jobs:
       - name: Build MinGW
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && matrix.platform != 'pc-linux-gnu' }}
         run: |
-          .github/scripts/toolchain/build-mingw.sh
+          .github/scripts/toolchain/build-mingw-winpthreads.sh
 
       - name: Build GCC libs
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
Unifies GCC configuration with MSYS2 packages. The main change is enabling `--enable-shared` which did not build properly. Requires https://github.com/Windows-on-ARM-Experiments/gcc-woarm64/pull/15 and https://github.com/Windows-on-ARM-Experiments/gcc-woarm64/pull/14 changes on GCC side.