### PR TITLE
Split `TARGET` into `ARCH` and `PLATFORM`

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -3,18 +3,18 @@
 source `dirname ${BASH_SOURCE[0]}`/config-mingw.sh
 
 .github/scripts/binutils/build.sh
-if [[ "$TARGET" = *linux* ]]; then
+if [[ "$PLATFORM" =~ linux ]]; then
     .github/scripts/binutils/install-cross-headers-libs.sh
 fi
-if [ "$BUILD_MINGW" = 1 ]; then
+if [[ "$PLATFORM" =~ mingw ]]; then
     .github/scripts/toolchain/build-mingw-headers.sh
 fi
 .github/scripts/toolchain/build-gcc.sh
-if [ "$BUILD_MINGW" = 1 ]; then
+if [[ "$PLATFORM" =~ mingw ]]; then
     .github/scripts/toolchain/build-mingw-crt.sh
 fi
 .github/scripts/toolchain/build-libgcc.sh
-if [ "$BUILD_MINGW" = 1 ]; then
+if [[ "$PLATFORM" =~ mingw ]]; then
     .github/scripts/toolchain/build-mingw.sh
 fi
 .github/scripts/toolchain/build-gcc-libs.sh

--- a/.github/scripts/config-mingw.sh
+++ b/.github/scripts/config-mingw.sh
@@ -4,11 +4,11 @@ source `dirname ${BASH_SOURCE[0]}`/config.sh
 
 MINGW_VERSION=${MINGW_VERSION:-mingw-w64-master}
 
-case "$TARGET" in
-    x86_64*)
+case "$ARCH" in
+    x86_64)
         MINGW_CONF="$MINGW_CONF --disable-lib32 --enable-lib64 --disable-libarm32 --disable-libarm64"
     ;;
-    aarch64*)
+    aarch64)
         MINGW_CONF="$MINGW_CONF --disable-lib32 --disable-lib64 --disable-libarm32 --enable-libarm64"
     ;;
 esac
@@ -24,10 +24,4 @@ esac
 
 if [ "$DEBUG" = 1 ] ; then
     MINGW_CONF="$MINGW_CONF --enable-debug"
-fi
-
-if [[ "$TARGET" == *mingw* ]]; then
-    BUILD_MINGW=1
-else
-    BUILD_MINGW=0
 fi

--- a/.github/scripts/config.ps1
+++ b/.github/scripts/config.ps1
@@ -4,9 +4,11 @@ if ( -not $env:OPENBLAS_VERSION ) { $env:OPENBLAS_VERSION = "openblas-develop" }
 if ( -not $env:OPENSSL_VERSION ) { $env:OPENSSL_VERSION = "openssl-master" }
 if ( -not $env:LIBJPEG_TURBO_VERSION) { $env:LIBJPEG_TURBO_VERSION="libjpeg-turbo-main" }
 
-if ( -not $env:TARGET ) { $env:TARGET = "aarch64-w64-mingw32" }
+if ( -not $env:ARCH ) { $env:ARCH = "aarch64" }
+if ( -not $env:PLATFORM ) { $env:PLATFORM = "w64-mingw32" }
 if ( -not $env:CRT ) { $env:CRT = "msvcrt" }
-if ( -not $env:TOOLCHAIN_NAME ) { $env:TOOLCHAIN_NAME = "$TARGET-$CRT" }
+if ( -not $env:TARGET ) { $env:TARGET = "$ARCH-$PLATFORM" }
+if ( -not $env:TOOLCHAIN_NAME ) { $env:TOOLCHAIN_NAME = "$ARCH-$PLATFORM-$CRT" }
 
 if ( -not $env:SOURCE_PATH ) { $env:SOURCE_PATH= "$PWD\code" }
 if ( -not $env:BUILD_PATH ) { $env:BUILD_PATH = "$PWD\build-$env:TOOLCHAIN_NAME" }

--- a/.github/scripts/config.sh
+++ b/.github/scripts/config.sh
@@ -13,17 +13,19 @@ OPENSSL_VERSION=${OPENSSL_VERSION:-openssl-master}
 LIBJPEG_TURBO_VERSION=${LIBJPEG_TURBO_VERSION:-libjpeg-turbo-main}
 FFMPEG_VERSION=${FFMPEG_VERSION:-ffmpeg-master}
 
-TARGET=${TARGET:-aarch64-w64-mingw32}
-if [[ "$TARGET" == *mingw* ]]; then
+ARCH=${ARCH:-aarch64}
+PLATFORM=${PLATFORM:-w64-mingw32}
+if [[ "$PLATFORM" =~ mingw ]]; then
     CRT=${CRT:-msvcrt}
 else
     CRT=${CRT:-libc}
 fi
-TOOLCHAIN_NAME=${TOOLCHAIN_NAME:-$TARGET-$CRT}
+TARGET=$ARCH-$PLATFORM
+TOOLCHAIN_NAME=${TOOLCHAIN_NAME:-$ARCH-$PLATFORM-$CRT}
 
-if [[ ("$TARGET" == *mingw* && ("$CRT" != "msvcrt" && "$CRT" != "ucrt")) ||
-    ("$TARGET" == *linux* && "$CRT" != "libc") ]]; then
-    echo "Unsupported target $TARGET with CRT $CRT!"
+if [[ ("$PLATFORM" =~ mingw && !("$CRT" =~ (msvcrt|ucrt))) ||
+    ("$PLATFORM" =~ linux && "$CRT" != "libc") ]]; then
+    echo "Unsupported target $PLATFORM with CRT $CRT!"
     exit 1
 fi
 

--- a/.github/scripts/toolchain/build-gcc.sh
+++ b/.github/scripts/toolchain/build-gcc.sh
@@ -12,7 +12,7 @@ if [ "$RUN_CONFIG" = 1 ] || [ ! -f "$GCC_BUILD_PATH/Makefile" ] ; then
 
     rm -rf $GCC_BUILD_PATH/*
 
-    case $TARGET in
+    case $PLATFORM in
         *mingw*)
             HOST_OPTIONS=" \
                 --enable-threads=win32 \

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -103,7 +103,8 @@ jobs:
             crt: libc
 
     env:
-      TARGET: ${{ matrix.arch }}-${{ matrix.platform }}
+      ARCH: ${{ matrix.arch }}
+      PLATFORM: ${{ matrix.platform }}
       CRT: ${{ matrix.crt }}
       PACK_TOOLCHAIN: ${{ matrix.arch == 'aarch64' && matrix.platform == 'w64-mingw32' && matrix.crt == 'msvcrt' }}
       TOOLCHAIN_NAME: ${{ matrix.arch }}-${{ matrix.platform }}-${{ matrix.crt }}


### PR DESCRIPTION
This adds further versatility for the builds scripts for decisions how the `configure` options should be constructed.