### PR TITLE
Increase retention to 30 days for GCC regression tests

### DIFF
--- a/.github/workflows/build-and-test-toolchain.yml
+++ b/.github/workflows/build-and-test-toolchain.yml
@@ -132,4 +132,4 @@ jobs:
         with:
           name: gcc-tests-${{ inputs.tag }}
           path: \\wsl.localhost\Ubuntu\root\artifacts\gcc-tests-${{ inputs.tag }}
-          retention-days: 3
+          retention-days: 30

--- a/.github/workflows/test-toolchain.yml
+++ b/.github/workflows/test-toolchain.yml
@@ -133,4 +133,4 @@ jobs:
         with:
           name: gcc-tests-results
           path: ${{ env.ARTIFACT_PATH }}/gcc-tests-results
-          retention-days: 3
+          retention-days: 30


### PR DESCRIPTION
Increases retention of GCC regression tests artifacts to 30 days.