### PR TITLE
Fix default branch for `workflow_dispatch`

### DIFF
--- a/.github/workflows/build-and-test-toolchain.yml
+++ b/.github/workflows/build-and-test-toolchain.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Checkout repository
         run: |
-          git clone --depth=1 https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build.git -b ${{ github.head_ref }} .
+          git clone --depth=1 https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build.git -b ${{ github.head_ref || 'main' }} .
 
       - name: Setup WSL environment
         run: |


### PR DESCRIPTION
Hopefully fixes the situation that for `workflow_dispatch` on `main` branch the `github.head_ref` is empty. Cannot be tested until in the `main` though.