### PR TITLE
Enable more languages for better test coverage

### DIFF
--- a/.github/scripts/install-dependencies.sh
+++ b/.github/scripts/install-dependencies.sh
@@ -16,6 +16,7 @@ echo "::group::Install Dependencies"
       dejagnu \
       docbook2x \
       flex \
+      gdc \
       libc6-dev-arm64-cross \
       libc6-dev-amd64-cross \
       texinfo \

--- a/.github/scripts/toolchain/build-gcc-stage1.sh
+++ b/.github/scripts/toolchain/build-gcc-stage1.sh
@@ -45,7 +45,7 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$GCC_BUILD_PATH/Makefile" ]]; then
                 ;;
             *mingw*)
                 TARGET_OPTIONS="$TARGET_OPTIONS \
-                    --enable-languages=c \
+                    --enable-languages=c,d \
                     --disable-isl-version-check \
                     --disable-rpath \
                     --disable-win32-registry \

--- a/.github/scripts/toolchain/build-gcc.sh
+++ b/.github/scripts/toolchain/build-gcc.sh
@@ -91,6 +91,7 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$GCC_BUILD_PATH/Makefile" ]]; then
                 ;;
         esac
 
+        # REMOVED: --enable-languages=ada,go,jit
         $SOURCE_PATH/gcc/configure \
             --prefix=$TOOLCHAIN_PATH \
             --build=$BUILD \
@@ -98,7 +99,7 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$GCC_BUILD_PATH/Makefile" ]]; then
             --target=$TARGET \
             --enable-static \
             --enable-shared \
-            --enable-languages=c,c++,lto,fortran \
+            --enable-languages=c,c++,d,fortran,lto,m2,objc,obj-c++ \
             --disable-bootstrap \
             --disable-multilib \
             --with-gnu-as \


### PR DESCRIPTION
Enables build of D, LTO, m2, ObjC, and Obj-c++ languages. The remaining languages, Ada, Go, and JIT, are harder to bootstrap for two stage cross-compilation build so it would be easier to test them on native toolchain.

Depends on Windows-on-ARM-Experiments/gcc-woarm64#33.