### PR TITLE
Add `aarch64-pc-cygwin` target to `advanced.yml`

### DIFF
--- a/.github/scripts/binutils/build.sh
+++ b/.github/scripts/binutils/build.sh
@@ -39,6 +39,16 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$BINUTILS_BUILD_PATH/Makefile" ]]; then
                 ;;
         esac
 
+        case "$ARCH-$PLATFORM" in
+            aarch64-*cygwin*)
+                # ADDED: --enable-targets=aarch64-pep
+                # ADDED: --disable-sim
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --enable-targets=aarch64-pep \
+                    --disable-sim"
+                ;;
+        esac
+
         $SOURCE_PATH/binutils/configure \
             --prefix=$TOOLCHAIN_PATH \
             --build=$BUILD \

--- a/.github/scripts/toolchain/build-cygwin.sh
+++ b/.github/scripts/toolchain/build-cygwin.sh
@@ -13,6 +13,12 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$CYGWIN_BUILD_PATH/Makefile" ]]; then
     echo "::group::Configure Cygwin"
         rm -rf $CYGWIN_BUILD_PATH/*
 
+        if [ "$DEBUG" = 1 ] ; then
+            HOST_OPTIONS="$HOST_OPTIONS \
+                --enable-debug \
+                --disable-lto"
+        fi
+
         (cd $CYGWIN_SOURCE_PATH/winsup && ./autogen.sh)
         if [[ "$STAGE" = "1" ]]; then
             (cd $CYGWIN_SOURCE_PATH && patch -p1 -i $PATCHES_PATH/cygwin/0001-fix-autogen.patch)
@@ -33,6 +39,7 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$CYGWIN_BUILD_PATH/Makefile" ]]; then
             --with-sysroot=$TOOLCHAIN_PATH \
             --with-build-sysroot=$TOOLCHAIN_PATH \
             --with-cross-bootstrap \
+            $HOST_OPTIONS \
             $TARGET_OPTIONS
     echo "::endgroup::"
 fi

--- a/.github/scripts/toolchain/build-gcc.sh
+++ b/.github/scripts/toolchain/build-gcc.sh
@@ -32,10 +32,12 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$GCC_BUILD_PATH/Makefile" ]]; then
         case "$PLATFORM" in
             *linux*)
                 TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --enable-shared \
                     --enable-threads=posix"
                 ;;
             *cygwin*)
                 # REMOVED: --libexecdir=/usr/lib
+                # REMOVED: --enable-shared for aarch64-pc-cygwin
                 # CHANGED: --enable-__cxa_atexit to --disable-__cxa_atexit
                 TARGET_OPTIONS="$TARGET_OPTIONS \
                     --enable-shared-libgcc \
@@ -61,6 +63,7 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$GCC_BUILD_PATH/Makefile" ]]; then
             *mingw*)
                 TARGET_OPTIONS="$TARGET_OPTIONS \
                     --libexecdir=$TOOLCHAIN_PATH/lib \
+                    --enable-shared \
                     --enable-threads=win32 \
                     --enable-graphite \
                     --enable-fully-dynamic-string \
@@ -89,6 +92,14 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$GCC_BUILD_PATH/Makefile" ]]; then
                 TARGET_OPTIONS="$TARGET_OPTIONS \
                     --disable-libsanitizer"
                 ;;
+            aarch64-pc-cygwin)
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --disable-shared"
+                ;;
+            x86_64-pc-cygwin)
+                TARGET_OPTIONS="$TARGET_OPTIONS \
+                    --enable-shared"
+                ;;
         esac
 
         # REMOVED: --enable-languages=ada,go,jit
@@ -98,7 +109,6 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$GCC_BUILD_PATH/Makefile" ]]; then
             --host=$HOST \
             --target=$TARGET \
             --enable-static \
-            --enable-shared \
             --enable-languages=c,c++,d,fortran,lto,m2,objc,obj-c++ \
             --disable-bootstrap \
             --disable-multilib \

--- a/.github/scripts/toolchain/build-mingw-crt.sh
+++ b/.github/scripts/toolchain/build-mingw-crt.sh
@@ -89,6 +89,8 @@ if [[ "$RUN_INSTALL" = 1 ]]; then
                     ln -fs w32api/libuserenv.a .
                     ln -fs w32api/libnetapi32.a .
                     ln -fs w32api/libdbghelp.a .
+                    ln -fs w32api/libonecore.a .
+                    ln -fs w32api/libpdh.a .
                 popd
                 ;;
         esac

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -146,8 +146,6 @@ jobs:
             crt: ucrt
           - platform: pc-cygwin
             crt: libc
-          - platform: pc-cygwin
-            arch: aarch64
 
     env:
       ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
This PR contains experiment to build `aarch64-pc-cygwin` toolchain capable of building working "Hello World" executable. The vast majority of Cygwin codebase that needs to be ported to Arm64 is not implemented though.