### PR TITLE
Use main branch for Cygwin as default

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -22,7 +22,7 @@ on:
       cygwin_branch:
         description: 'Cygwin branch to build'
         required: false
-        default: 'woarm64'
+        default: 'main'
       cygwin_packages_branch:
         description: 'Cygwin packages branch to build'
         required: false
@@ -30,7 +30,7 @@ on:
       cocom_branch:
         description: 'COCOM branch to build'
         required: false
-        default: 'main'
+        default: 'master'
       openblas_branch:
         description: 'OpenBLAS branch to test'
         required: false
@@ -73,7 +73,7 @@ env:
   MINGW_VERSION: mingw-w64-master
 
   CYGWIN_REPO: Windows-on-ARM-Experiments/newlib-cygwin
-  CYGWIN_BRANCH: ${{ inputs.cygwin_branch || 'woarm64' }}
+  CYGWIN_BRANCH: ${{ inputs.cygwin_branch || 'main' }}
   CYGWIN_VERSION: cygwin-master
 
   CYGWIN_PACKAGES_REPO: Windows-on-ARM-Experiments/cygwin-packages


### PR DESCRIPTION
Rather use main branch Cygwin as the aarch64 differences will be applied as patches. Also, fixes the default branch for COCOM to `master` from `main` which does not exist. Next step could be adding automatic synchronization with upstream to `rebase.yml` (not in this PR though).