### PR TITLE
Do not fail pipeline when compare-gcc-results.sh discovers differences

### DIFF
--- a/.github/scripts/toolchain/compare-gcc-results.sh
+++ b/.github/scripts/toolchain/compare-gcc-results.sh
@@ -14,7 +14,7 @@ echo "::group::Compare GCC tests results"
     for TEST_FILE in $TEST_PATH/*.sum; do
         BASELINE_FIILE=$BASELINE_PATH/`basename $TEST_FILE`
         $SOURCE_PATH/$GCC_VERSION/contrib/compare_tests $BASELINE_FIILE $TEST_FILE > \
-          $RESULTS_PATH/`basename $TEST_FILE .sum`.diff
+          $RESULTS_PATH/`basename $TEST_FILE .sum`.diff && true
     done
 echo "::endgroup::"
 


### PR DESCRIPTION
Fixes pipeline fail when `compare-gcc-results.sh` detected regressions.