### PR TITLE
Fix baseline GCC and MinGW branch for test-toolchain.yml

### DIFF
--- a/.github/workflows/test-toolchain.yml
+++ b/.github/workflows/test-toolchain.yml
@@ -86,8 +86,8 @@ jobs:
     uses: ./.github/workflows/build-and-test-toolchain.yml
     with:
       binutils_branch: ${{ inputs.binutils_branch_changes }}
-      gcc_branch: ${{ inputs.gcc_branch_test || 'aarch64-patch-stage1-v11' }}
-      mingw_branch: ${{ inputs.mingw_branch_test }}
+      gcc_branch: ${{ inputs.gcc_branch_changes || 'aarch64-patch-stage1-v11' }}
+      mingw_branch: ${{ inputs.mingw_branch_changes }}
       arch: ${{ inputs.arch }}
       platform: ${{ inputs.platform }}
       crt: ${{ inputs.crt }}


### PR DESCRIPTION
This explains weird regressions detected during patch set testing.