### PR TITLE
Fix dependency symlinks for `*-pc-cygwin` targets

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -18,12 +18,15 @@ fi
 
 if [ "$RUN_BOOTSTRAP" = 1 ]; then
     .github/scripts/install-dependencies.sh
-    .github/scripts/install-libraries.sh
 fi
 
 if [[ "$PLATFORM" =~ cygwin ]]; then
     .github/scripts/binutils/patch-cygwin.sh 1
     .github/scripts/toolchain/patch-cygwin.sh 1
+fi
+
+if [ "$RUN_BOOTSTRAP" = 1 ]; then
+    .github/scripts/install-libraries.sh
 fi
 
 .github/scripts/binutils/build.sh
@@ -54,6 +57,10 @@ if [[ "$PLATFORM" =~ cygwin ]]; then
 
     .github/scripts/binutils/patch-cygwin.sh 2
     .github/scripts/toolchain/patch-cygwin.sh 2
+fi
+
+if [ "$RUN_BOOTSTRAP" = 1 ]; then
+    .github/scripts/install-libraries.sh
 fi
 
 .github/scripts/toolchain/build-gcc.sh

--- a/.github/scripts/install-dependencies.sh
+++ b/.github/scripts/install-dependencies.sh
@@ -4,7 +4,7 @@ source `dirname ${BASH_SOURCE[0]}`/config.sh
 
 echo "::group::Install Dependencies"
     sudo apt update
-    sudo apt install -y build-essential binutils-for-build texinfo bison flex ccache docbook2x xmlto zlib1g-dev libc6-dev-arm64-cross libc6-dev-amd64-cross dejagnu
+    sudo apt install -y build-essential autoconf automake autotools-dev binutils-for-build texinfo bison flex ccache docbook2x xmlto zlib1g-dev libc6-dev-arm64-cross libc6-dev-amd64-cross dejagnu
 echo "::endgroup::"
 
 echo 'Success!'

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -244,25 +244,25 @@ jobs:
         run: |
           .github/scripts/install-dependencies.sh
 
-      - name: Install libraries
-        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
-        run: |
-          .github/scripts/install-libraries.sh
-
       - name: Patch binutils stage1
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && matrix.platform == 'pc-cygwin' }}
         run: |
           .github/scripts/binutils/patch-cygwin.sh 1
 
-      - name: Build binutils
-        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
-        run: |
-          .github/scripts/binutils/build.sh
-
       - name: Patch toolchain stage1
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && matrix.platform == 'pc-cygwin' }}
         run: |
           .github/scripts/toolchain/patch-cygwin.sh 1
+
+      - name: Install libraries
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
+        run: |
+          .github/scripts/install-libraries.sh
+
+      - name: Build binutils
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
+        run: |
+          .github/scripts/binutils/build.sh
 
       - name: Install cross headers and libraries
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && matrix.platform == 'pc-linux-gnu' }}
@@ -308,6 +308,11 @@ jobs:
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && matrix.platform == 'pc-cygwin' }}
         run: |
           .github/scripts/toolchain/patch-cygwin.sh 2
+
+      - name: Install libraries
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
+        run: |
+          .github/scripts/install-libraries.sh
 
       - name: Build GCC stage2
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
Fixes issue that `.github/scripts/binutils/patch-cygwin.sh` and `.github/scripts/toolchain/patch-cygwin.sh` scripts reset the repositories and thus remove the symlinks.