### PR TITLE
Test relocation and small code model fixes

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -34,7 +34,7 @@ on:
       openblas_branch:
         description: 'OpenBLAS branch to test'
         required: false
-        default: 'v0.3.26'
+        default: 'develop'
       openssl_branch:
         description: 'OpenSSL branch to test'
         required: false
@@ -85,7 +85,7 @@ env:
   COCOM_VERSION: cocom-master
 
   OPENBLAS_REPO: OpenMathLib/OpenBLAS.git
-  OPENBLAS_BRANCH: ${{ inputs.openblas_branch || 'v0.3.26' }}
+  OPENBLAS_BRANCH: ${{ inputs.openblas_branch || 'develop' }}
   OPENBLAS_VERSION: openblas-develop
 
   ZLIB_REPO: madler/zlib
@@ -101,7 +101,7 @@ env:
   OPENSSL_VERSION: openssl-master
 
   LIBJPEG_TURBO_REPO: libjpeg-turbo/libjpeg-turbo
-  LIBJPEG_TURBO_BRANCH: develop
+  LIBJPEG_TURBO_BRANCH: 3.0.2
   LIBJPEG_TURBO_VERSION: libjpeg-turbo-main
 
   FFMPEG_REPO: FFmpeg/FFmpeg

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -101,7 +101,7 @@ env:
   OPENSSL_VERSION: openssl-master
 
   LIBJPEG_TURBO_REPO: libjpeg-turbo/libjpeg-turbo
-  LIBJPEG_TURBO_BRANCH: 3.0.2
+  LIBJPEG_TURBO_BRANCH: develop
   LIBJPEG_TURBO_VERSION: libjpeg-turbo-main
 
   FFMPEG_REPO: FFmpeg/FFmpeg

--- a/patches/ffmpeg/fate.patch
+++ b/patches/ffmpeg/fate.patch
@@ -11,19 +11,6 @@ index 78652c47bd..53d13375db 100644
  
  ALLFFLIBS = avcodec avdevice avfilter avformat avutil postproc swscale swresample
  
-diff --git a/configure b/configure
-index a89cfa6d95..aefb6fa23d 100755
---- a/configure
-+++ b/configure
-@@ -4802,7 +4802,7 @@ probe_cc(){
-                 warn "gcc 4.2 is outdated and may miscompile FFmpeg. Please use a newer compiler." ;;
-             esac
-         fi
--        _cflags_speed='-O3'
-+        _cflags_speed='-O2'
-         _cflags_size='-Os'
-     elif $_cc --version 2>/dev/null | grep -q ^icc; then
-         _type=icc
 diff --git a/doc/Makefile b/doc/Makefile
 index 67586e4b74..d7432290a0 100644
 --- a/doc/Makefile

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(
   bigdata-test.c
   chkstk-test.c
   dll-test.c
+  large-struct-test.c
   gtest_like_c.c
   main.c
   math-test.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,8 @@ add_executable(
   pdata-test.c
   sjlj-test.c
   sscanf-double.c
+  static-function-test.c
+  static-function.c
   struct-test.c
   varargs-test.c
 )

--- a/tests/large-struct-test.c
+++ b/tests/large-struct-test.c
@@ -1,0 +1,34 @@
+/*
+   Tests relocation and data in a large (>1MB) struct
+*/
+
+#include "gtest_like_c.h"
+
+struct LargeStruct {
+  unsigned char member1[1<<20];
+  unsigned char member2;
+  unsigned char member3;
+  unsigned char member4;
+};
+
+static struct LargeStruct large_struct;
+
+void fn1(char *test) {
+    *test = 0xab;
+}
+
+int large_struct_relocation()
+{
+    memset(&large_struct, 0xaa, sizeof(large_struct));
+    fn1(&large_struct.member2);
+    large_struct.member3 = 0xac;
+
+    int success = *(&large_struct.member2 - 1) == 0xaa && large_struct.member2 == 0xab &&
+		large_struct.member3 == 0xac && large_struct.member4 == 0xaa;
+    return success;
+}
+
+TEST(Aarch64MinGW, LargeStructRelocationTest)
+{
+    ASSERT_TRUE(large_struct_relocation());
+}

--- a/tests/main.c
+++ b/tests/main.c
@@ -13,6 +13,7 @@ TEST(Aarch64MinGW, PrintfDoubleTest);
 TEST(Aarch64MinGW, TestUnwindStack);
 TEST(Aarch64MinGW, SJLJTest);
 TEST(Aarch64MinGW, SscanfDoubleTest);
+TEST(Aarch64MinGW, StaticFunctionTest);
 TEST(Aarch64MinGW, StructTest);
 TEST(Aarch64MinGW, TestVaList);
 TEST(Aarch64MinGW, TestSPrintf);
@@ -52,6 +53,7 @@ int main(int argc, char **argv) {
         DECLARE_TEST(Aarch64MinGW, TestUnwindStack),
         DECLARE_TEST(Aarch64MinGW, SJLJTest),
         DECLARE_TEST(Aarch64MinGW, SscanfDoubleTest),
+        DECLARE_TEST(Aarch64MinGW, StaticFunctionTest),
         DECLARE_TEST(Aarch64MinGW, StructTest),
         DECLARE_TEST(Aarch64MinGW, TestVaList),
         DECLARE_TEST(Aarch64MinGW, TestSPrintf),

--- a/tests/main.c
+++ b/tests/main.c
@@ -5,6 +5,7 @@
 TEST(Aarch64MinGW, BigDataTest);
 TEST(Aarch64MinGW, CHKSTKTest);
 TEST(Aarch64MinGW, DllTest);
+TEST(Aarch64MinGW, LargeStructRelocationTest);
 TEST(Aarch64MinGW, MathTest);
 TEST(Aarch64MinGW, NestedFunction);
 TEST(Aarch64MinGW, OmpTest);
@@ -43,6 +44,7 @@ int main(int argc, char **argv) {
         DECLARE_TEST(Aarch64MinGW, BigDataTest),
         DECLARE_TEST(Aarch64MinGW, CHKSTKTest),
         DECLARE_TEST(Aarch64MinGW, DllTest),
+        DECLARE_TEST(Aarch64MinGW, LargeStructRelocationTest),
         DECLARE_TEST(Aarch64MinGW, MathTest),
         DECLARE_TEST(Aarch64MinGW, NestedFunction),
         DECLARE_TEST(Aarch64MinGW, OmpTest),

--- a/tests/static-function-test.c
+++ b/tests/static-function-test.c
@@ -1,0 +1,23 @@
+/*
+   Tests reading double from a string
+*/
+
+#include "gtest_like_c.h"
+
+extern int (*get_test_static(void))(int* val);
+
+int static_function_test()
+{
+    int (*test_static)(int* val) = get_test_static();
+    int i = 10;
+
+    if (test_static(&i) != 10)
+        return 0;
+
+    return 1;
+}
+
+TEST(Aarch64MinGW, StaticFunctionTest)
+{
+    ASSERT_TRUE(static_function_test());
+}

--- a/tests/static-function-test.c
+++ b/tests/static-function-test.c
@@ -11,7 +11,7 @@ int static_function_test()
     int (*test_static)(int* val) = get_test_static();
     int i = 10;
 
-    if (test_static(&i) != 10)
+    if (test_static(&i) != 11)
         return 0;
 
     return 1;

--- a/tests/static-function.c
+++ b/tests/static-function.c
@@ -1,0 +1,15 @@
+/*
+   Tests reading double from a string
+*/
+
+
+static int test_static(int* val)
+{
+    return *val;
+}
+
+
+int (*get_test_static(void))(int* val) 
+{
+    return test_static;
+}

--- a/tests/static-function.c
+++ b/tests/static-function.c
@@ -5,7 +5,7 @@
 
 static int test_static(int* val)
 {
-    return *val;
+    return *val + 1;
 }
 
 


### PR DESCRIPTION
Validate fixes to resolve the following issues

Relocation overflow when struct is large
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/130

Relocation overflow issue when building FFmpeg with -O3
https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/issues/100

Building OpenBLAS develop branch
Relocations and small code model fixes
a static function call by reference from another object file.