### PR TITLE
Shared `libgcc` can now be enabled for `aarch64-w64-mingw32`

### DIFF
--- a/.github/scripts/config.ps1
+++ b/.github/scripts/config.ps1
@@ -16,3 +16,8 @@ if ( -not $env:OPENBLAS_TESTS_PATH ) { $env:OPENBLAS_TESTS_PATH = "$PWD\openblas
 if ( -not $env:OPENSSL_TESTS_PATH ) { $env:OPENSSL_TESTS_PATH = "$PWD\openssl-tests" }
 if ( -not $env:LIBJPEG_TURBO_TESTS_PATH ) { $env:LIBJPEG_TURBO_TESTS_PATH = "$PWD\libjpeg-turbo-tests" }
 if ( -not $env:FFMPEG_TESTS_PATH ) { $env:FFMPEG_TESTS_PATH = "$PWD\ffmpeg-tests" }
+
+if ( -not $env:RUNTIME_PACKAGE_NAME ) { $env:RUNTIME_PACKAGE_NAME = "$env:TOOLCHAIN_NAME-runtime.tar.gz" }
+if ( -not $env:TESTS_PACKAGE_NAME ) { $env:TESTS_PACKAGE_NAME = "$env:TOOLCHAIN_NAME-tests.tar.gz" }
+
+$env:PATH += ";$env:TOOLCHAIN_PATH\bin;$env:ARTIFACT_PATH\bin"

--- a/.github/scripts/config.sh
+++ b/.github/scripts/config.sh
@@ -35,6 +35,7 @@ BUILD_MAKE_OPTIONS=${BUILD_MAKE_OPTIONS:-V=1 -j$(nproc)}
 TOOLCHAIN_PATH=${TOOLCHAIN_PATH:-~/cross-$TOOLCHAIN_NAME}
 TOOLCHAIN_FILE=${TOOLCHAIN_FILE:-$ROOT_PATH/.github/cmake/$TARGET.cmake}
 TOOLCHAIN_PACKAGE_NAME=${TOOLCHAIN_PACKAGE_NAME:-$TOOLCHAIN_NAME-toolchain.tar.gz}
+RUNTIME_PACKAGE_NAME=${RUNTIME_PACKAGE_NAME:-$TOOLCHAIN_NAME-runtime.tar.gz}
 DEJAGNU_FILE=${DEJAGNU_FILE:-$ROOT_PATH/.github/scripts/toolchain/site.exp}
 
 ZLIB_PATH=${ZLIB_PATH:-~/zlib}
@@ -57,6 +58,12 @@ FFMPEG_TESTS_PATH=${FFMPEG_TESTS_PATH:-~/ffmpeg-tests}
 CCACHE_LIB_DIR=/usr/lib/ccache
 TOOLCHAIN_CCACHE_LIB_DIR=$TOOLCHAIN_PATH/lib/ccache
 
+if [[ -f $SOURCE_PATH/gcc/gcc/BASE-VER ]]; then
+    GCC_VERSION=$(cat $SOURCE_PATH/gcc/gcc/BASE-VER)
+else
+    GCC_VERSION="15.0.0"
+fi
+
 DEBUG=${DEBUG:-0} # Enable debug build.
 CCACHE=${CCACHE:-0} # Enable usage of ccache.
 RUN_BOOTSTRAP=${RUN_BOOTSTRAP:-0} # Bootstrap dependencies during the build.
@@ -67,7 +74,7 @@ RUN_CONFIG=${RUN_CONFIG:-1} # Run configuration step.
 RUN_INSTALL=${RUN_INSTALL:-1} # Run installation step.
 DELETE_BUILD=${DELETE_BUILD:-0} # Delete build folders after successful builds.
 
-PATH="$PATH:$TOOLCHAIN_PATH/bin"
+PATH="$PATH:$TOOLCHAIN_PATH/bin:$ARTIFACT_PATH/bin"
 if [[ "$CCACHE" = 1 ]]; then
     PATH=$CCACHE_LIB_DIR:$TOOLCHAIN_CCACHE_LIB_DIR:$PATH
     export CCACHE_DIR=$CCACHE_DIR_PATH

--- a/.github/scripts/ffmpeg/unpack-tests.ps1
+++ b/.github/scripts/ffmpeg/unpack-tests.ps1
@@ -1,6 +1,9 @@
 . $PSScriptRoot\..\config.ps1
 
-Remove-Item $env:FFMPEG_TESTS_PATH -Recurse -Force -ErrorAction Ignore
+Write-Output "::group::Unpack FFmpeg tests"
+    Remove-Item $env:FFMPEG_TESTS_PATH -Recurse -Force -ErrorAction Ignore
+    Set-PSDebug -Trace 0 # echo off
+    Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-ffmpeg-tests.zip -DestinationPath $env:FFMPEG_TESTS_PATH
+Write-Output "::endgroup::"
 
-Set-PSDebug -Trace 0 # echo off
-Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-ffmpeg-tests.zip -DestinationPath $env:FFMPEG_TESTS_PATH
+Write-Output 'Success!'

--- a/.github/scripts/libjpeg-turbo/unpack-tests.ps1
+++ b/.github/scripts/libjpeg-turbo/unpack-tests.ps1
@@ -1,4 +1,9 @@
 . $PSScriptRoot\..\config.ps1
 
-Remove-Item $env:LIBJPEG_TURBO_TESTS_PATH -Recurse -Force -ErrorAction Ignore
-Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-libjpeg-turbo-tests.zip -DestinationPath $env:LIBJPEG_TURBO_TESTS_PATH
+Write-Output "::group::Unpack libjpeg-turbo tests"
+    Remove-Item $env:LIBJPEG_TURBO_TESTS_PATH -Recurse -Force -ErrorAction Ignore
+    Set-PSDebug -Trace 0 # echo off
+    Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-libjpeg-turbo-tests.zip -DestinationPath $env:LIBJPEG_TURBO_TESTS_PATH
+Write-Output "::endgroup::"
+
+Write-Output 'Success!'

--- a/.github/scripts/openblas/unpack-tests.ps1
+++ b/.github/scripts/openblas/unpack-tests.ps1
@@ -1,4 +1,9 @@
 . $PSScriptRoot\..\config.ps1
 
-Remove-Item $env:OPENBLAS_TESTS_PATH -Recurse -Force -ErrorAction Ignore
-Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-openblas-tests.zip -DestinationPath $env:OPENBLAS_TESTS_PATH
+Write-Output "::group::Unpack OpenBLAS tests"
+    Remove-Item $env:OPENBLAS_TESTS_PATH -Recurse -Force -ErrorAction Ignore
+    Set-PSDebug -Trace 0 # echo off
+    Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-openblas-tests.zip -DestinationPath $env:OPENBLAS_TESTS_PATH
+Write-Output "::endgroup::"
+
+Write-Output 'Success!'

--- a/.github/scripts/openssl/unpack-tests.ps1
+++ b/.github/scripts/openssl/unpack-tests.ps1
@@ -1,4 +1,9 @@
 . $PSScriptRoot\..\config.ps1
 
-Remove-Item $env:OPENSSL_TESTS_PATH -Recurse -Force -ErrorAction Ignore
-Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-openssl-tests.zip -DestinationPath $env:OPENSSL_TESTS_PATH
+Write-Output "::group::Unpack OpenSSL tests"
+    Remove-Item $env:OPENSSL_TESTS_PATH -Recurse -Force -ErrorAction Ignore
+    Set-PSDebug -Trace 0 # echo off
+    Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-openssl-tests.zip -DestinationPath $env:OPENSSL_TESTS_PATH
+Write-Output "::endgroup::"
+
+Write-Output 'Success!'

--- a/.github/scripts/tests/build.sh
+++ b/.github/scripts/tests/build.sh
@@ -3,9 +3,7 @@
 source `dirname ${BASH_SOURCE[0]}`/../config.sh
 
 echo "::group::Build Aarch64 tests"
-    cd tests
+    cd $ROOT_PATH/tests
     cmake -S . -B build
     cmake --build build
-
-    cp $TOOLCHAIN_PATH/$TARGET/bin/*.dll build/bin
 echo "::endgroup::"

--- a/.github/scripts/tests/pack.sh
+++ b/.github/scripts/tests/pack.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../config.sh
+
+echo "::group::Pack tests"
+    tar czf $ARTIFACT_PATH/$TESTS_PACKAGE_NAME -C $ROOT_PATH/tests/build/bin/ .
+echo "::endgroup::"
+
+echo 'Success!'

--- a/.github/scripts/tests/unpack.ps1
+++ b/.github/scripts/tests/unpack.ps1
@@ -1,0 +1,7 @@
+. $PSScriptRoot\..\config.ps1
+
+Write-Output "::group::Unpack tests"
+    tar xzf $env:ARTIFACT_PATH\$env:TESTS_PACKAGE_NAME -C $env:ARTIFACT_PATH
+Write-Output "::endgroup::"
+
+Write-Output 'Success!'

--- a/.github/scripts/toolchain/build-gcc.sh
+++ b/.github/scripts/toolchain/build-gcc.sh
@@ -89,11 +89,6 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$GCC_BUILD_PATH/Makefile" ]]; then
                 TARGET_OPTIONS="$TARGET_OPTIONS \
                     --disable-libsanitizer"
                 ;;
-            aarch64-*mingw*)
-                # CHANGED: --enable-shared to --disable-shared
-                TARGET_OPTIONS="$TARGET_OPTIONS \
-                    --disable-shared"
-                ;;
         esac
 
         $SOURCE_PATH/gcc/configure \

--- a/.github/scripts/toolchain/build-mingw-crt.sh
+++ b/.github/scripts/toolchain/build-mingw-crt.sh
@@ -30,8 +30,6 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_BUILD_PATH/Makefile" ]]; then
                     --disable-lib64 \
                     --disable-libarm32 \
                     --enable-libarm64"
-                CFLAGS="$CFLAGS \
-                    -mno-outline-atomics"
             ;;
         esac
 

--- a/.github/scripts/toolchain/build-mingw-winpthreads.sh
+++ b/.github/scripts/toolchain/build-mingw-winpthreads.sh
@@ -16,19 +16,12 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_BUILD_PATH/Makefile" ]]; then
                 --enable-debug"
         fi
 
-        case "$ARCH" in
-            aarch64)
-                CFLAGS="$CFLAGS \
-                    -mno-outline-atomics"
-            ;;
-        esac
-
         $SOURCE_PATH/mingw/mingw-w64-libraries/winpthreads/configure \
             --prefix=$TOOLCHAIN_PATH/$TARGET \
             --build=$BUILD \
             --host=$TARGET \
             --enable-static \
-            --enable-shared \
+            --disable-shared \
             $HOST_OPTIONS \
             $TARGET_OPTIONS \
             CFLAGS="$CFLAGS"

--- a/.github/scripts/toolchain/build-mingw.sh
+++ b/.github/scripts/toolchain/build-mingw.sh
@@ -30,8 +30,6 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_BUILD_PATH/Makefile" ]]; then
                     --disable-lib64 \
                     --disable-libarm32 \
                     --enable-libarm64"
-                CFLAGS="$CFLAGS \
-                    -mno-outline-atomics"
             ;;
         esac
 
@@ -62,6 +60,8 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_BUILD_PATH/Makefile" ]]; then
             --prefix=$TOOLCHAIN_PATH/$TARGET \
             --build=$BUILD \
             --host=$TARGET \
+            --enable-static \
+            --enable-shared \
             $HOST_OPTIONS \
             $TARGET_OPTIONS \
             CFLAGS="$CFLAGS"

--- a/.github/scripts/toolchain/pack-runtime-mock.sh
+++ b/.github/scripts/toolchain/pack-runtime-mock.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../config.sh
+
+echo "::group::Pack runtime mock"
+    mkdir -p $ARTIFACT_PATH
+    tar czf $ARTIFACT_PATH/$RUNTIME_PACKAGE_NAME --files-from /dev/null
+echo "::endgroup::"
+
+echo 'Success!'

--- a/.github/scripts/toolchain/pack-runtime.sh
+++ b/.github/scripts/toolchain/pack-runtime.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../config.sh
+
+echo "::group::Pack runtime"
+    mkdir -p $ARTIFACT_PATH
+    find $TOOLCHAIN_PATH -name "*.dll" | tar --transform 's|.*/|./bin/|' -czf $ARTIFACT_PATH/$RUNTIME_PACKAGE_NAME -T -
+echo "::endgroup::"
+
+echo 'Success!'

--- a/.github/scripts/toolchain/unpack-runtime.ps1
+++ b/.github/scripts/toolchain/unpack-runtime.ps1
@@ -1,0 +1,7 @@
+. $PSScriptRoot\..\config.ps1
+
+Write-Output "::group::Unpack runtime"
+    tar xzf $env:ARTIFACT_PATH\$env:RUNTIME_PACKAGE_NAME -C $env:ARTIFACT_PATH
+Write-Output "::endgroup::"
+
+Write-Output 'Success!'

--- a/.github/scripts/zlib/unpack.ps1
+++ b/.github/scripts/zlib/unpack.ps1
@@ -1,6 +1,11 @@
 . $PSScriptRoot\..\config.ps1
 
-Remove-Item $env:ZLIB_PATH  -Recurse -Force -ErrorAction Ignore
-Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-zlib.zip -DestinationPath $env:ZLIB_PATH
-Copy-Item $env:ZLIB_PATH/bin/*.dll $env:OPENSSL_TESTS_PATH/apps/
-Copy-Item $env:ZLIB_PATH/bin/*.dll $env:OPENSSL_TESTS_PATH/test/
+Write-Output "::group::Unpack zlib"
+    Remove-Item $env:ZLIB_PATH  -Recurse -Force -ErrorAction Ignore
+    Set-PSDebug -Trace 0 # echo off
+    Expand-Archive -LiteralPath $env:ARTIFACT_PATH\$env:TOOLCHAIN_NAME-zlib.zip -DestinationPath $env:ZLIB_PATH
+    Copy-Item $env:ZLIB_PATH/bin/*.dll $env:OPENSSL_TESTS_PATH/apps/
+    Copy-Item $env:ZLIB_PATH/bin/*.dll $env:OPENSSL_TESTS_PATH/test/
+Write-Output "::endgroup::"
+
+Write-Output 'Success!'

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -99,6 +99,7 @@ env:
   TOOLCHAIN_PATH: ${{ github.workspace }}/cross
   TOOLCHAIN_NAME: aarch64-w64-mingw32-msvcrt
   TOOLCHAIN_PACKAGE_NAME: aarch64-w64-mingw32-msvcrt-toolchain.tar.gz
+  RUNTIME_PACKAGE_NAME: aarch64-w64-mingw32-msvcrt-runtime.tar.gz
 
   SOURCE_PATH: ${{ github.workspace }}/code
   BUILD_PATH: ${{ github.workspace }}/build
@@ -139,6 +140,7 @@ jobs:
       PACK_TOOLCHAIN: ${{ matrix.arch == 'aarch64' && matrix.platform == 'w64-mingw32' && matrix.crt == 'msvcrt' }}
       TOOLCHAIN_NAME: ${{ matrix.arch }}-${{ matrix.platform }}-${{ matrix.crt }}
       TOOLCHAIN_PACKAGE_NAME: ${{ matrix.arch }}-${{ matrix.platform }}-${{ matrix.crt }}-toolchain.tar.gz
+      RUNTIME_PACKAGE_NAME: ${{ matrix.arch }}-${{ matrix.platform }}-${{ matrix.crt }}-runtime.tar.gz
       TESTS_PACKAGE_NAME: ${{ matrix.arch }}-${{ matrix.crt }}-tests.tar.gz
 
     steps:
@@ -348,10 +350,20 @@ jobs:
         run: |
           .github/scripts/toolchain/pack.sh
 
+      - name: Pack runtime
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.PACK_TOOLCHAIN == 'true' }}
+        run: |
+          .github/scripts/toolchain/pack-runtime.sh
+
       - name: Pack toolchain mock
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.PACK_TOOLCHAIN != 'true' }}
         run: |
           .github/scripts/toolchain/pack-mock.sh
+
+      - name: Pack runtime mock
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.PACK_TOOLCHAIN != 'true' }}
+        run: |
+          .github/scripts/toolchain/pack-runtime-mock.sh
 
       - name: Upload build folder
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && failure() }}
@@ -361,12 +373,20 @@ jobs:
           retention-days: 1
           path: ${{ env.BUILD_PATH }}
 
-      - name: Upload artifact
+      - name: Upload toolchain artifact
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' || env.PACK_TOOLCHAIN == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TOOLCHAIN_PACKAGE_NAME }}
           path: ${{ env.ARTIFACT_PATH }}/${{ env.TOOLCHAIN_PACKAGE_NAME }}
+          retention-days: 3
+
+      - name: Upload runtime artifact
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' || env.PACK_TOOLCHAIN == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.RUNTIME_PACKAGE_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}/${{ env.RUNTIME_PACKAGE_NAME }}
           retention-days: 3
 
     outputs:
@@ -403,13 +423,13 @@ jobs:
 
       - name: Pack tests
         run: |
-          tar czf ${{ env.TESTS_PACKAGE_NAME }} -C tests/build/bin/ .
+          .github/scripts/tests/pack.sh
 
       - name: Upload build-aarch64-mingw-tests
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TESTS_PACKAGE_NAME }}
-          path: ${{ env.TESTS_PACKAGE_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}/${{ env.TESTS_PACKAGE_NAME }}
           retention-days: 3
 
   execute-aarch64-tests:
@@ -425,15 +445,25 @@ jobs:
         with:
           path: ${{ github.workspace }}
 
+      - name: Download ${{ env.TOOLCHAIN_NAME }} runtime
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.RUNTIME_PACKAGE_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}
+
       - name: Download ${{ env.TOOLCHAIN_NAME }} tests
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.TESTS_PACKAGE_NAME }}
           path: ${{ env.ARTIFACT_PATH }}
 
-      - name: Unpack tests
+      - name: Unpack ${{ env.TOOLCHAIN_NAME }} runtime
         run: |
-          tar xzf ${{ env.ARTIFACT_PATH }}\${{ env.TESTS_PACKAGE_NAME }} -C ${{ env.ARTIFACT_PATH }}
+          .github/scripts/toolchain/unpack-runtime.ps1
+
+      - name: Unpack ${{ env.TOOLCHAIN_NAME }} tests
+        run: |
+          .github/scripts/tests/unpack.ps1
 
       - name: Execute ${{ env.TOOLCHAIN_NAME }} tests
         run:
@@ -495,11 +525,21 @@ jobs:
         with:
           path: ${{ github.workspace }}
 
+      - name: Download ${{ env.TOOLCHAIN_NAME }} runtime
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.RUNTIME_PACKAGE_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}
+
       - name: Download OpenBLAS tests
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.TOOLCHAIN_NAME }}-openblas-tests
           path: ${{ env.ARTIFACT_PATH }}
+
+      - name: Unpack ${{ env.TOOLCHAIN_NAME }} runtime
+        run: |
+          .github/scripts/toolchain/unpack-runtime.ps1
 
       - name: Unpack OpenBLAS tests
         run: |
@@ -509,7 +549,7 @@ jobs:
         shell: bash
         run: |
           .github/scripts/openblas/execute-tests.sh
-  
+
   build-zlib:
     needs: [build-toolchain]
     runs-on: ubuntu-latest 
@@ -705,21 +745,31 @@ jobs:
           ref: ${{ env.OPENSSL_BRANCH }}
           path: ${{ env.SOURCE_PATH }}/openssl
 
+      - name: Download ${{ env.TOOLCHAIN_NAME }} runtime
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.RUNTIME_PACKAGE_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}
+
       - name: Download OpenSSL tests
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.TOOLCHAIN_NAME }}-openssl-tests
           path: ${{ env.ARTIFACT_PATH }}
 
-      - name: Unpack OpenSSL tests
-        run: |
-          .github/scripts/openssl/unpack-tests.ps1
-
       - name: Download zlib
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.TOOLCHAIN_NAME }}-zlib
           path: ${{ env.ARTIFACT_PATH }}
+
+      - name: Unpack ${{ env.TOOLCHAIN_NAME }} runtime
+        run: |
+          .github/scripts/toolchain/unpack-runtime.ps1
+
+      - name: Unpack OpenSSL tests
+        run: |
+          .github/scripts/openssl/unpack-tests.ps1
   
       - name: Unpack zlib
         run: |
@@ -803,11 +853,21 @@ jobs:
         with:
           path: ${{ github.workspace }}
 
+      - name: Download ${{ env.TOOLCHAIN_NAME }} runtime
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.RUNTIME_PACKAGE_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}
+
       - name: Download libjpeg-turbo tests
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.TOOLCHAIN_NAME }}-libjpeg-turbo-tests
           path: ${{ env.ARTIFACT_PATH }}
+
+      - name: Unpack ${{ env.TOOLCHAIN_NAME }} runtime
+        run: |
+          .github/scripts/toolchain/unpack-runtime.ps1
 
       - name: Unpack libjpeg-turbo tests
         run: |
@@ -894,11 +954,21 @@ jobs:
         run: |
           .github/scripts/ffmpeg/patch.sh
 
+      - name: Download ${{ env.TOOLCHAIN_NAME }} runtime
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.RUNTIME_PACKAGE_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}
+
       - name: Download FFmpeg tests
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.TOOLCHAIN_NAME }}-ffmpeg-tests
           path: ${{ env.ARTIFACT_PATH }}
+
+      - name: Unpack ${{ env.TOOLCHAIN_NAME }} runtime
+        run: |
+          .github/scripts/toolchain/unpack-runtime.ps1
 
       - name: Unpack FFmpeg tests
         run: |


### PR DESCRIPTION
After Windows-on-ARM-Experiments/gcc-woarm64#21 was merged, shared `libgcc` can be enabled for `aarch64-w64-mingw32`.