### PR TITLE
Add tests to validate weak references

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,8 @@ add_executable(
   static-function.c
   struct-test.c
   varargs-test.c
+  weak-references-test.c
+  weak-references.c
 )
 
 target_link_libraries(

--- a/tests/main.c
+++ b/tests/main.c
@@ -18,6 +18,7 @@ TEST(Aarch64MinGW, StructTest);
 TEST(Aarch64MinGW, TestVaList);
 TEST(Aarch64MinGW, TestSPrintf);
 TEST(Aarch64MinGW, TestVaArgPack);
+TEST(Aarch64MinGW, WeakReferencesTest);
 
 int main(int argc, char **argv) {
 
@@ -57,7 +58,8 @@ int main(int argc, char **argv) {
         DECLARE_TEST(Aarch64MinGW, StructTest),
         DECLARE_TEST(Aarch64MinGW, TestVaList),
         DECLARE_TEST(Aarch64MinGW, TestSPrintf),
-        DECLARE_TEST(Aarch64MinGW, TestVaArgPack)
+        DECLARE_TEST(Aarch64MinGW, TestVaArgPack),
+        DECLARE_TEST(Aarch64MinGW, WeakReferencesTest)
     };
 
     return gtest_like_c_run_tests(tests, sizeof(tests) / sizeof(tests[0]), gtest_filter);

--- a/tests/weak-references-test.c
+++ b/tests/weak-references-test.c
@@ -1,0 +1,12 @@
+int weak_fn2(void) 
+{
+  return 10;
+}
+
+int weak_fn4(void)
+{
+  return 11;
+}
+
+int weak_v2 = 12;
+int weak_v4 = 13;

--- a/tests/weak-references.c
+++ b/tests/weak-references.c
@@ -1,0 +1,27 @@
+#include "gtest_like_c.h"
+
+__attribute__((weak)) int weak_fn1(void);
+__attribute__((weak)) int weak_fn2(void);
+[[gnu::weak]] int weak_fn3(void);
+[[gnu::weak]] int weak_fn4(void);
+
+__attribute__((weak)) int weak_v1;
+__attribute__((weak)) int weak_v2;
+[[gnu::weak]] int weak_v3;
+[[gnu::weak]] int weak_v4;
+
+int weak_references()
+{
+  if (weak_fn1 || weak_fn3 || weak_fn2() != 10 || weak_fn4() != 11)
+    return 0;
+
+  if (weak_v1 || weak_v3 || weak_v2 != 12 || weak_v4 != 13)
+    return 0;
+
+  return 1;
+}
+
+TEST(Aarch64MinGW, WeakReferencesTest)
+{
+    ASSERT_TRUE(weak_references());
+}


### PR DESCRIPTION
This change validates weak references support after following fixes.
[Support relocation for weak references](https://github.com/Windows-on-ARM-Experiments/binutils-woarm64/pull/4)
[Support weak references](https://github.com/Windows-on-ARM-Experiments/gcc-woarm64/pull/28)