### PR TITLE
Move ccache enablement into a separate script

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -2,22 +2,12 @@
 
 source `dirname ${BASH_SOURCE[0]}`/config.sh
 
-if [[ "$CCACHE" = 1 ]]; then
-  mkdir -p $TOOLCHAIN_PATH/lib/ccache
-  pushd $TOOLCHAIN_PATH/lib/ccache
-    if ! [ -f $TARGET-gcc ]; then
-      ln -s /usr/bin/ccache $TARGET-gcc
-    fi
-    if ! [ -f $TARGET-g++ ]; then
-      ln -s /usr/bin/ccache $TARGET-g++
-    fi
-  popd
-
-  ccache -z
-fi
-
 if [[ "$RUN_BOOTSTRAP" = 1 ]]; then
     .github/scripts/install-dependencies.sh
+fi
+
+if [[ "$CCACHE" = 1 ]]; then
+    .github/scripts/enable-ccache.sh
 fi
 
 if [[ "$UPDATE_SOURCES" = 1 ]]; then
@@ -31,6 +21,10 @@ fi
 
 if [[ "$RUN_BOOTSTRAP" = 1 || "$RESET_SOURCES" = 1 ]]; then
     .github/scripts/install-libraries.sh
+fi
+
+if [[ "$CCACHE" = 1 ]]; then
+    ccache -sv
 fi
 
 .github/scripts/binutils/build.sh
@@ -77,7 +71,7 @@ if [[ "$PLATFORM" =~ cygwin ]]; then
 fi
 
 if [[ "$CCACHE" = 1 ]]; then
-    ccache -s
+    ccache -sv
 fi
 
 echo 'Success!'

--- a/.github/scripts/config.sh
+++ b/.github/scripts/config.sh
@@ -38,6 +38,7 @@ SOURCE_PATH=${SOURCE_PATH:-$PWD/code}
 DOWNLOADS_PATH=${DOWNLOADS_PATH:-$PWD/downloads}
 PATCHES_PATH=${PATCHES_PATH:-$PWD/patches}
 BUILD_PATH=${BUILD_PATH:-$PWD/build-$TOOLCHAIN_NAME}
+CCACHE_DIR_PATH=${CCACHE_DIR_PATH:-$PWD/ccache}
 ARTIFACT_PATH=${ARTIFACT_PATH:-$PWD/artifact}
 BUILD_MAKE_OPTIONS=${BUILD_MAKE_OPTIONS:-V=1 -j$(nproc)}
 TOOLCHAIN_PATH=${TOOLCHAIN_PATH:-~/cross-$TOOLCHAIN_NAME}
@@ -62,6 +63,9 @@ TESTS_PACKAGE_NAME=${TESTS_PACKAGE_NAME:-$TOOLCHAIN_NAME-tests.tar.gz}
 FFMPEG_PATH=${FFMPEG_PATH:-~/ffmpeg}
 FFMPEG_TESTS_PATH=${FFMPEG_TESTS_PATH:-~/ffmpeg-tests}
 
+CCACHE_LIB_DIR=/usr/lib/ccache
+TOOLCHAIN_CCACHE_LIB_DIR=$TOOLCHAIN_PATH/lib/ccache
+
 DEBUG=${DEBUG:-0} # Enable debug build.
 CCACHE=${CCACHE:-0} # Enable usage of ccache.
 RUN_BOOTSTRAP=${RUN_BOOTSTRAP:-0} # Bootstrap dependencies during the build.
@@ -70,8 +74,8 @@ RESET_SOURCES=${RESET_SOURCES:-0} # Reset source code repositories before update
 RUN_CONFIG=${RUN_CONFIG:-1} # Run configuration step.
 RUN_INSTALL=${RUN_INSTALL:-1} # Run installation step.
 
-PATH=$PATH:$TOOLCHAIN_PATH/bin
-
+PATH="$PATH:$TOOLCHAIN_PATH/bin"
 if [[ "$CCACHE" = 1 ]]; then
-    PATH=/usr/lib/ccache:$TOOLCHAIN_PATH/lib/ccache:$PATH
+    PATH=$CCACHE_LIB_DIR:$TOOLCHAIN_CCACHE_LIB_DIR:$PATH
+    export CCACHE_DIR=$CCACHE_DIR_PATH
 fi

--- a/.github/scripts/enable-ccache.sh
+++ b/.github/scripts/enable-ccache.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/config.sh
+
+mkdir -p $TOOLCHAIN_CCACHE_LIB_DIR
+
+echo "::group::Add $TARGET toolchain to ccache"
+    pushd $TOOLCHAIN_CCACHE_LIB_DIR
+        ln -sf /usr/bin/ccache $TARGET-gcc
+        ln -sf /usr/bin/ccache $TARGET-g++
+        ln -sf /usr/bin/ccache $TARGET-c++
+    popd
+
+    ls -al $CCACHE_LIB_DIR
+    ls -al $TOOLCHAIN_CCACHE_LIB_DIR
+    which gcc || true
+    which $BUILD-gcc || true
+    which $HOST-gcc || true
+    which $TARGET-gcc || true
+echo "::endgroup::"
+
+# Zero statistics.
+ccache -z

--- a/.github/scripts/toolchain/execute-gcc-tests.sh
+++ b/.github/scripts/toolchain/execute-gcc-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CCACHE=0 # Disable ccache for testing.
+
 source `dirname ${BASH_SOURCE[0]}`/../config.sh
 
 TAG=$1


### PR DESCRIPTION
This is a small refactoring that will be used for adding MSYS2 specific ccache enablement. It also disables ccache for testing - only MSYS2 has an issue related to that but, in general, caching during testing might be quite dangerous.

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10218137685