### PR TITLE
Add option to select single GCC module, tests filter, and target and host boards to `execute-gcc-tests.sh`

### DIFF
--- a/.github/scripts/toolchain/execute-gcc-tests.sh
+++ b/.github/scripts/toolchain/execute-gcc-tests.sh
@@ -5,6 +5,11 @@ CCACHE=0 # Disable ccache for testing.
 source `dirname ${BASH_SOURCE[0]}`/../config.sh
 
 TAG=$1
+MODULE=$2
+FILTER=$3
+TARGET_BOARD=${4:-wsl-sim}
+HOST_BOARD=${5:-}
+
 GCC_BUILD_PATH=$BUILD_PATH/gcc
 TEST_RESULTS_PATH=$ARTIFACT_PATH/gcc-tests-$TAG
 
@@ -14,8 +19,19 @@ echo "::group::Execute GCC tests"
     done
 
     cd $GCC_BUILD_PATH
-    make $BUILD_MAKE_OPTIONS -k check \
-        RUNTESTFLAGS="--target_board wsl-sim" \
+    if [[ -z "$MODULE" ]]; then
+        MAKE_TARGET="check"
+    else
+        MAKE_TARGET="check-$MODULE"
+    fi
+    if [[ -n "$TARGET_BOARD" ]]; then
+        TARGET_BOARD="--target-board $TARGET_BOARD"
+    fi
+    if [[ -n "$HOST_BOARD" ]]; then
+        HOST_BOARD="--host-board $HOST_BOARD"
+    fi
+    make $BUILD_MAKE_OPTIONS -k $MAKE_TARGET \
+        RUNTESTFLAGS="$FILTER $HOST_BOARD $TARGET_BOARD" \
         DEJAGNU="$DEJAGNU_FILE" \
         CHECK_TEST_FRAMEWORK=1 \
         || echo "Error"

--- a/.github/workflows/build-and-test-toolchain.yml
+++ b/.github/workflows/build-and-test-toolchain.yml
@@ -30,6 +30,14 @@ on:
       tag:
         description: 'Tag to use for the artifact'
         required: true
+      gcc_module:
+        description: 'GCC module to test'
+        required: false
+        default: ''
+      gcc_test_filter:
+        description: 'GCC test filter'
+        required: false
+        default: ''
   workflow_call:
     inputs:
       binutils_branch:
@@ -46,6 +54,10 @@ on:
         type: string
       tag:
         type: string
+      gcc_module:
+        type: string
+      gcc_test_filter:
+        type: string
 
 env:
   BINUTILS_BRANCH: ${{ inputs.binutils_branch || 'woarm64' }}
@@ -55,6 +67,10 @@ env:
   ARCH: ${{ inputs.arch || 'x86_64' }}
   PLATFORM: ${{ inputs.platform || 'w64-mingw32' }}
   CRT: ${{ inputs.crt || 'msvcrt' }}
+  
+  TAG: ${{ inputs.tag || 'test' }}
+  MODULE: ${{ inputs.gcc_module || '' }}
+  FILTER: ${{ inputs.gcc_test_filter || '' }}
 
   RUN_BOOTSTRAP: 1
   UPDATE_SOURCES: 1
@@ -65,7 +81,7 @@ jobs:
     runs-on: windows-latest
 
     env:
-      WSLENV: BINUTILS_BRANCH:GCC_BRANCH:MINGW_BRANCH:ARCH:PLATFORM:CRT:RUN_BOOTSTRAP:UPDATE_SOURCES:GITHUB_OUTPUT/p
+      WSLENV: BINUTILS_BRANCH:GCC_BRANCH:MINGW_BRANCH:ARCH:PLATFORM:CRT:TAG:MODULE:FILTER:RUN_BOOTSTRAP:UPDATE_SOURCES:GITHUB_OUTPUT/p
 
     defaults:
       run:
@@ -100,11 +116,11 @@ jobs:
       - name: Execute GCC tests
         run: |
           cd ~/work
-          .github/scripts/toolchain/execute-gcc-tests.sh ${{ inputs.tag }}
+          .github/scripts/toolchain/execute-gcc-tests.sh "${{ env.TAG }}" "${{ env.MODULE }}" "${{ env.FILTER }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: gcc-tests-${{ inputs.tag }}
-          path: ${{ steps.get-wsl-paths.outputs.artifact-path }}\gcc-tests-${{ inputs.tag }}
+          name: gcc-tests-${{ env.TAG }}
+          path: ${{ steps.get-wsl-paths.outputs.artifact-path }}\gcc-tests-${{ env.TAG }}
           retention-days: 30


### PR DESCRIPTION
Adds options to `execute-gcc-tests.sh` script for selecting single GCC module, GCC tests filter, and DejaGNU target and host boards.

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10265746800