### PR TITLE
Enable ccache for `main.yml`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,11 @@ env:
   GCC_BRANCH: ${{ inputs.gcc_branch || 'woarm64' }}
   MINGW_BRANCH: ${{ inputs.mingw_branch || 'woarm64' }}
 
+  BUILD_PATH: ${{ github.workspace }}/build
+  CCACHE_DIR_PATH: ${{ github.workspace }}/ccache
   TOOLCHAIN_PATH: ${{ github.workspace }}/cross
+
+  CCACHE: 1
 
 jobs:
   build-toolchain:
@@ -33,10 +37,37 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
+      - name: Get cache key
+        id: get-cache-key
+        run: |
+          echo "timestamp=$(date -u --iso-8601=seconds)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CCACHE_DIR_PATH }}
+          key: main-gcc-ccache-${{ steps.get-cache-key.outputs.timestamp }}
+          restore-keys: main-gcc-ccache-
+
       - name: Run Build
         run: |
           ./build.sh
+
+      - name: Save Ccache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CCACHE_DIR_PATH }}
+          key: main-gcc-ccache-${{ steps.get-cache-key.outputs.timestamp }}
+
+      - name: Upload build folder
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          retention-days: 1
+          path: ${{ env.BUILD_PATH }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Enables ccache for `main.yml` workflow. Similar changes for other workflows will follow albeit the cache won't be shared.

Depends on https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/pull/159