### PR TITLE
Fix repository branch when the `build-and-test-toolchain.yml` workflow is triggered manually

### DIFF
--- a/.github/workflows/build-and-test-toolchain.yml
+++ b/.github/workflows/build-and-test-toolchain.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Checkout repository
         run: |
-          git clone --depth=1 https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build.git -b ${{ github.head_ref || 'main' }} .
+          git clone --depth=1 https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build.git -b ${{ github.head_ref || github.ref_name || 'main' }} .
 
       - name: Setup WSL environment
         run: |


### PR DESCRIPTION
`github.head_ref` is valid only for `pull_request` trigger, for `worflow_dispatch` trigger the `github.ref_name` should be used.