### PR TITLE
Fix the way how environment variables are injected into WSL environment

### DIFF
--- a/.github/workflows/build-and-test-toolchain.yml
+++ b/.github/workflows/build-and-test-toolchain.yml
@@ -48,30 +48,24 @@ on:
         type: string
 
 env:
-  BINUTILS_REPO: Windows-on-ARM-Experiments/binutils-woarm64
   BINUTILS_BRANCH: ${{ inputs.binutils_branch || 'woarm64' }}
-  BINUTILS_VERSION: binutils
-
-  GCC_REPO: Windows-on-ARM-Experiments/gcc-woarm64
   GCC_BRANCH: ${{ inputs.gcc_branch || 'woarm64' }}
-  GCC_VERSION: gcc
-
-  MINGW_REPO: Windows-on-ARM-Experiments/mingw-woarm64
   MINGW_BRANCH: ${{ inputs.mingw_branch || 'woarm64' }}
-  MINGW_VERSION: mingw-w64
 
   ARCH: ${{ inputs.arch || 'x86_64' }}
   PLATFORM: ${{ inputs.platform || 'w64-mingw32' }}
   CRT: ${{ inputs.crt || 'msvcrt' }}
 
-  SOURCE_PATH: ~/code
-  DOWNLOADS_PATH: ~/downloads
-  ARTIFACT_PATH: ~/artifacts
+  RUN_BOOTSTRAP: 1
+  UPDATE_SOURCES: 1
 
 jobs:
   build-and-test-toolchain:
     name: Build and test toolchain
     runs-on: windows-latest
+
+    env:
+      WSLENV: BINUTILS_BRANCH:GCC_BRANCH:MINGW_BRANCH:ARCH:PLATFORM:CRT:RUN_BOOTSTRAP:UPDATE_SOURCES:GITHUB_OUTPUT/p
 
     defaults:
       run:
@@ -87,49 +81,30 @@ jobs:
 
       - name: Checkout repository
         run: |
-          git clone --depth=1 https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build.git -b ${{ github.head_ref || github.ref_name || 'main' }} .
+          cd ~
+          git clone --depth=1 ${{ github.server_url }}/${{ github.repository }}.git -b ${{ github.head_ref || github.ref_name || 'main' }} work
 
-      - name: Setup WSL environment
+      - name: Get WSL paths
+        id: get-wsl-paths
         run: |
-          echo " \
-            export BINUTILS_VERSION=${{ env.BINUTILS_VERSION }}
-            export GCC_VERSION=${{ env.GCC_VERSION }}
-            export MINGW_VERSION=${{ env.MINGW_VERSION }}
-            export ARCH=${{ env.ARCH }}
-            export PLATFORM=${{ env.PLATFORM }}
-            export CRT=${{ env.CRT }}
-            export TOOLCHAIN_NAME=${{ env.ARCH }}-${{ env.PLATFORM }}-${{ env.CRT }}
-            export SOURCE_PATH=${{ env.SOURCE_PATH }}
-            export DOWNLOADS_PATH=${{ env.DOWNLOADS_PATH }}
-            export ARTIFACT_PATH=${{ env.ARTIFACT_PATH }}
-            export RUN_BOOTSTRAP=1
-          " > environment.sh
-
-      - name: Checkout binutils
-        run: |
-          git clone --depth=1 https://github.com/${{ env.BINUTILS_REPO }}.git -b ${{ env.BINUTILS_BRANCH }} ${{ env.SOURCE_PATH }}/${{ env.BINUTILS_VERSION }}
-
-      - name: Checkout GCC
-        run: |
-          git clone --depth=1 https://github.com/${{ env.GCC_REPO }}.git -b ${{ env.GCC_BRANCH }} ${{ env.SOURCE_PATH }}/${{ env.GCC_VERSION }}
-
-      - name: Checkout MinGW
-        run: |
-          git clone --depth=1 https://github.com/${{ env.MINGW_REPO }}.git -b ${{ env.MINGW_BRANCH }} ${{ env.SOURCE_PATH }}/${{ env.MINGW_VERSION }}
+          cd ~/work
+          source .github/scripts/config.sh
+          mkdir -p $ARTIFACT_PATH
+          echo "artifact-path=`wslpath -w $ARTIFACT_PATH`" >> $GITHUB_OUTPUT
 
       - name: Build toolchain
         run: |
-          source environment.sh
+          cd ~/work
           .github/scripts/build.sh
 
       - name: Execute GCC tests
         run: |
-          source environment.sh
+          cd ~/work
           .github/scripts/toolchain/execute-gcc-tests.sh ${{ inputs.tag }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: gcc-tests-${{ inputs.tag }}
-          path: \\wsl.localhost\Ubuntu\root\artifacts\gcc-tests-${{ inputs.tag }}
+          path: ${{ steps.get-wsl-paths.outputs.artifact-path }}\gcc-tests-${{ inputs.tag }}
           retention-days: 30


### PR DESCRIPTION
The previous state was just a workaround. Now I've figured out how it should be done properly.

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10265560530