### PR TITLE
Delete build folders after successful builds

### DIFF
--- a/.github/scripts/binutils/build.sh
+++ b/.github/scripts/binutils/build.sh
@@ -59,6 +59,9 @@ echo "::endgroup::"
 if [[ "$RUN_INSTALL" = 1 ]]; then
     echo "::group::Install binutils"
         make install
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $BINUTILS_BUILD_PATH
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/config.sh
+++ b/.github/scripts/config.sh
@@ -74,6 +74,7 @@ RESET_SOURCES=${RESET_SOURCES:-0} # Reset source code repositories before update
 APPLY_PATCHES=${APPLY_PATCHES:-1} # Patch source repositories for targets requiring it.
 RUN_CONFIG=${RUN_CONFIG:-1} # Run configuration step.
 RUN_INSTALL=${RUN_INSTALL:-1} # Run installation step.
+DELETE_BUILD=${DELETE_BUILD:-0} # Delete build folders after successful builds.
 
 PATH="$PATH:$TOOLCHAIN_PATH/bin"
 if [[ "$CCACHE" = 1 ]]; then

--- a/.github/scripts/toolchain/build-cocom.sh
+++ b/.github/scripts/toolchain/build-cocom.sh
@@ -26,6 +26,9 @@ echo "::endgroup::"
 if [[ "$RUN_INSTALL" = 1 ]]; then
     echo "::group::Install COCOM"
         make install
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $COCOM_BUILD_PATH 
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-cygwin.sh
+++ b/.github/scripts/toolchain/build-cygwin.sh
@@ -48,6 +48,9 @@ echo "::endgroup::"
 if [[ "$RUN_INSTALL" = 1 ]]; then
     echo "::group::Install Cygwin"
         make install
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $CYGWIN_BUILD_PATH
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-gcc-stage1.sh
+++ b/.github/scripts/toolchain/build-gcc-stage1.sh
@@ -87,6 +87,9 @@ echo "::endgroup::"
 if [[ "$RUN_INSTALL" = 1 ]]; then
     echo "::group::Install GCC stage1"
         make install
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $GCC_BUILD_PATH
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-gcc.sh
+++ b/.github/scripts/toolchain/build-gcc.sh
@@ -120,6 +120,9 @@ echo "::endgroup::"
 if [[ "$RUN_INSTALL" = 1 ]]; then
     echo "::group::Install GCC"
         make install
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $GCC_BUILD_PATH
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-mingw-crt.sh
+++ b/.github/scripts/toolchain/build-mingw-crt.sh
@@ -94,6 +94,10 @@ if [[ "$RUN_INSTALL" = 1 ]]; then
                 popd
                 ;;
         esac
+
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $MINGW_BUILD_PATH
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-mingw-headers.sh
+++ b/.github/scripts/toolchain/build-mingw-headers.sh
@@ -59,6 +59,10 @@ if [[ "$RUN_INSTALL" = 1 ]]; then
 
         # Symlink for gcc
         ln -sf $TOOLCHAIN_PATH/$TARGET $TOOLCHAIN_PATH/mingw
+
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $MINGW_HEADERS_BUILD_PATH
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-mingw-winpthreads.sh
+++ b/.github/scripts/toolchain/build-mingw-winpthreads.sh
@@ -42,6 +42,9 @@ echo "::endgroup::"
 if [[ "$RUN_INSTALL" = 1 ]]; then
     echo "::group::Install MinGW winpthreads"
         make install
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $MINGW_BUILD_PATH
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/scripts/toolchain/build-mingw.sh
+++ b/.github/scripts/toolchain/build-mingw.sh
@@ -75,6 +75,9 @@ echo "::endgroup::"
 if [[ "$RUN_INSTALL" = 1 ]]; then
     echo "::group::Install MinGW"
         make install
+        if [[ "$DELETE_BUILD" = 1 ]]; then
+            rm -rf $MINGW_BUILD_PATH
+        fi
     echo "::endgroup::"
 fi
 

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -115,6 +115,8 @@ env:
   SOURCE_PATH: ${{ github.workspace }}/code
   ARTIFACT_PATH: ${{ github.workspace }}/artifact
 
+  DELETE_BUILD: 1
+
 jobs:
   build-toolchain:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ env:
   TOOLCHAIN_PATH: ${{ github.workspace }}/cross
 
   CCACHE: 1
+  DELETE_BUILD: 1
 
 jobs:
   build-toolchain:


### PR DESCRIPTION
Enabling ccache on `advanced.yml` revealed that we are reaching disk space limit of the default GHA runners for `x86_64-pc-cygwin` build (https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10283146312/job/28456360182). This PR will save some space by deleting build folders of individual components after they succesfully build.