### PR TITLE
Build tests in the main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           ./build.sh
 
+      - name: Build tests
+        run: |
+          .github/scripts/tests/build.sh
+
       - name: Save Ccache
         if: always()
         uses: actions/cache/save@v4


### PR DESCRIPTION
The change is needed to check if tests can be built on bootstrapping. It will be useful to use aarch64 runners to validate it.