### PR TITLE
Fixes of aarch64 testing in WSL environment

### DIFF
--- a/.github/scripts/toolchain/execute-gcc-tests.sh
+++ b/.github/scripts/toolchain/execute-gcc-tests.sh
@@ -13,6 +13,8 @@ HOST_BOARD=${5:-}
 GCC_BUILD_PATH=$BUILD_PATH/gcc
 TEST_RESULTS_PATH=$ARTIFACT_PATH/gcc-tests-$TAG
 
+PATH="$TOOLCHAIN_PATH/bin:$PATH"
+
 echo "::group::Execute GCC tests"
     for FILE in `find $GCC_BUILD_PATH -path '*testsuite*.log' -or -path '*testsuite*.sum'`; do
         rm $FILE

--- a/.github/scripts/toolchain/wsl-sim.exp
+++ b/.github/scripts/toolchain/wsl-sim.exp
@@ -2,7 +2,7 @@ set SIM "true &&"
 
 load_generic_config "sim"
 
-set_board_info target_install {x86_64-w64-mingw32}
+set_board_info target_install {x86_64-w64-mingw32, aarch64-w64-mingw32}
 set_board_info gcc,timeout 5000
 set_board_info sim,timeout 5000
 


### PR DESCRIPTION
This PR has non-observable effect on x64 testing (https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10307874341) because the host system already contains x64 assembler but fixes test failures when x64 assembler is used for aarch64 testing. In other words, it prefers binutils produced by the build over the sytem ones.

Allows to run native tests using WSL interop increasing the number of tests executed from ~400k to ~800k and fixes test failures like:
```
Executing on host: /root/mingw-woarm64-build/build-aarch64-w64-mingw32-msvcrt/gcc/gcc/xgcc -B/root/mingw-woarm64-build/build-aarch64-w64-mingw32-msvcrt/gcc/gcc/    -fdiagnostics-plain-output    -O1  -w -c -o pr106433.o /root/mingw-woarm64-build/code/gcc-master/gcc/testsuite/gcc.c-torture/compile/pr106433.c    (timeout = 300)
spawn -ignore SIGHUP /root/mingw-woarm64-build/build-aarch64-w64-mingw32-msvcrt/gcc/gcc/xgcc -B/root/mingw-woarm64-build/build-aarch64-w64-mingw32-msvcrt/gcc/gcc/ -fdiagnostics-plain-output -O1 -w -c -o pr106433.o /root/mingw-woarm64-build/code/gcc-master/gcc/testsuite/gcc.c-torture/compile/pr106433.c
/tmp/ccu7EAi0.s: Assembler messages:
/tmp/ccu7EAi0.s:43: Error: unknown pseudo-op: `.variant_pcs'
/tmp/ccu7EAi0.s:92: Error: unknown pseudo-op: `.variant_pcs'
/tmp/ccu7EAi0.s:152: Error: unknown pseudo-op: `.variant_pcs'
/tmp/ccu7EAi0.s:201: Error: unknown pseudo-op: `.variant_pcs'
compiler exited with status 1
```