### PR TITLE
Fix GCC target tests execution

### DIFF
--- a/.github/scripts/install-dependencies.sh
+++ b/.github/scripts/install-dependencies.sh
@@ -4,7 +4,7 @@ source `dirname ${BASH_SOURCE[0]}`/config.sh
 
 echo "::group::Install Dependencies"
     sudo apt update
-    sudo apt install -y build-essential autoconf automake autotools-dev binutils-for-build texinfo bison flex ccache docbook2x xmlto zlib1g-dev libc6-dev-arm64-cross libc6-dev-amd64-cross dejagnu
+    sudo apt install -y build-essential autogen autoconf automake autotools-dev binutils-for-build texinfo bison flex ccache docbook2x xmlto zlib1g-dev libc6-dev-arm64-cross libc6-dev-amd64-cross dejagnu
 echo "::endgroup::"
 
 echo 'Success!'

--- a/.github/scripts/toolchain/execute-gcc-tests.sh
+++ b/.github/scripts/toolchain/execute-gcc-tests.sh
@@ -27,10 +27,10 @@ echo "::group::Execute GCC tests"
         MAKE_TARGET="check-$MODULE"
     fi
     if [[ -n "$TARGET_BOARD" ]]; then
-        TARGET_BOARD="--target-board $TARGET_BOARD"
+        TARGET_BOARD="--target_board=$TARGET_BOARD"
     fi
     if [[ -n "$HOST_BOARD" ]]; then
-        HOST_BOARD="--host-board $HOST_BOARD"
+        HOST_BOARD="--host_board=$HOST_BOARD"
     fi
     make $BUILD_MAKE_OPTIONS -k $MAKE_TARGET \
         RUNTESTFLAGS="$FILTER $HOST_BOARD $TARGET_BOARD" \


### PR DESCRIPTION
There is no `--target-board` option of the `runtest` executable, the correct syntax is `--target_board=board_name`. Also, without `autogen` installed the target tests complain that `autogen` is missing.