### PR TITLE
Change `$TAG` to `$DIR` in `execute-gcc-tests.sh` and `create-gcc-summary.sh` so it is easier to use them standalone

### DIFF
--- a/.github/scripts/toolchain/create-gcc-summary.sh
+++ b/.github/scripts/toolchain/create-gcc-summary.sh
@@ -2,7 +2,7 @@
 
 source `dirname ${BASH_SOURCE[0]}`/../config.sh
 
-TAG=$1
+DIR=$1
 
 print_summary() {
     local TITLE=$1
@@ -47,7 +47,7 @@ TOTAL_UNSUPPORTED_TESTS=0
 TOTAL_DEJAGNU_ERRORS=0
 
 set +x # echo off
-for SUM_FILE in "$ARTIFACT_PATH/gcc-tests-$TAG/"*.sum; do
+for FILE in `find $DIR -path '*.sum'`; do
     EXPECTED_PASSES=0
     UNEXPECTED_FAILURES=0
     UNEXPECTED_SUCCESSES=0
@@ -80,9 +80,9 @@ for SUM_FILE in "$ARTIFACT_PATH/gcc-tests-$TAG/"*.sum; do
                 DEJAGNU_ERRORS=$(($DEJAGNU_ERRORS + $(echo "$LINE" | awk '{print $5}')))
                 ;;
         esac
-    done <"$SUM_FILE"
+    done < "$FILE"
 
-    print_summary "Summary for \`$(basename $SUM_FILE)\`" $EXPECTED_PASSES $UNEXPECTED_FAILURES \
+    print_summary "Summary for \`$(basename $FILE)\`" $EXPECTED_PASSES $UNEXPECTED_FAILURES \
         $UNEXPECTED_SUCCESSES $EXPECTED_FAILURES $UNRESOLVED_TESTCASES $UNSUPPORTED_TESTS \
         $DEJAGNU_ERRORS
 

--- a/.github/scripts/toolchain/execute-gcc-tests.sh
+++ b/.github/scripts/toolchain/execute-gcc-tests.sh
@@ -4,14 +4,14 @@ CCACHE=0 # Disable ccache for testing.
 
 source `dirname ${BASH_SOURCE[0]}`/../config.sh
 
-TAG=$1
+DIR=$1
 MODULE=$2
 FILTER=$3
 TARGET_BOARD=${4:-wsl-sim}
 HOST_BOARD=${5:-}
 
 GCC_BUILD_PATH=$BUILD_PATH/gcc
-TEST_RESULTS_PATH=$ARTIFACT_PATH/gcc-tests-$TAG
+TEST_RESULTS_PATH=$ARTIFACT_PATH/$DIR
 
 PATH="$TOOLCHAIN_PATH/bin:$PATH"
 

--- a/.github/scripts/toolchain/group-gcc-test-failures.sh
+++ b/.github/scripts/toolchain/group-gcc-test-failures.sh
@@ -2,12 +2,11 @@
 
 source `dirname ${BASH_SOURCE[0]}`/../config.sh
 
-TAG=$1
-SUMMARY_OUTPUT=$2
+DIR=$1
 
 python3 $ROOT_PATH/.github/scripts/toolchain/group-gcc-test-failures.py \
-    --dir $ARTIFACT_PATH/gcc-tests-$TAG >> \
-    $ARTIFACT_PATH/gcc-tests-$TAG/grouped-test-failures.md
+    --dir $ARTIFACT_PATH/$DIR >> \
+    $ARTIFACT_PATH/$DIR/grouped-test-failures.md
 
-cat $ARTIFACT_PATH/gcc-tests-$TAG/grouped-test-failures.md |
-    $ROOT_PATH/.github/scripts/toolchain/extract-most-frequent-failures.sh 10 >> $SUMMARY_OUTPUT
+cat $ARTIFACT_PATH/$DIR/grouped-test-failures.md |
+    $ROOT_PATH/.github/scripts/toolchain/extract-most-frequent-failures.sh 10

--- a/.github/workflows/build-and-test-toolchain.yml
+++ b/.github/workflows/build-and-test-toolchain.yml
@@ -113,14 +113,15 @@ jobs:
           mkdir -p $BUILD_PATH
           mkdir -p $CCACHE_DIR_PATH
           mkdir -p $ARTIFACT_PATH
-          echo "build-path=`wslpath -w $BUILD_PATH`" >> $GITHUB_OUTPUT
-          echo "ccache-dir-path=`wslpath -w $CCACHE_DIR_PATH`" >> $GITHUB_OUTPUT
-          echo "artifact-path=`wslpath -w $ARTIFACT_PATH`" >> $GITHUB_OUTPUT
+          echo "build-path-win=`wslpath -w $BUILD_PATH`" >> $GITHUB_OUTPUT
+          echo "ccache-dir-path-win=`wslpath -w $CCACHE_DIR_PATH`" >> $GITHUB_OUTPUT
+          echo "artifact-path-win=`wslpath -w $ARTIFACT_PATH`" >> $GITHUB_OUTPUT
+          echo "artifact-path-wsl=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
 
       - name: Restore Ccache
         uses: actions/cache/restore@v4
         with:
-          path: ${{ steps.get-wsl-paths.outputs.ccache-dir-path }}
+          path: ${{ steps.get-wsl-paths.outputs.ccache-dir-path-win }}
           key: build-and-test-gcc-ccache-${{ steps.get-cache-key.outputs.timestamp }}
           restore-keys: build-and-test-gcc-ccache-
 
@@ -132,27 +133,24 @@ jobs:
         if: always()
         uses: actions/cache/save@v4
         with:
-          path: ${{ steps.get-wsl-paths.outputs.ccache-dir-path }}
+          path: ${{ steps.get-wsl-paths.outputs.ccache-dir-path-win }}
           key: build-and-test-gcc-ccache-${{ steps.get-cache-key.outputs.timestamp }}
 
       - name: Execute GCC tests
         run: |
-          ~/work/.github/scripts/toolchain/execute-gcc-tests.sh "${{ env.TAG }}" "${{ env.MODULE }}" "${{ env.FILTER }}"
+          ~/work/.github/scripts/toolchain/execute-gcc-tests.sh "gcc-tests-${{ env.TAG }}" \
+            "${{ env.MODULE }}" "${{ env.FILTER }}"
 
       - name: Create summary
         run: |
-          source ~/work/.github/scripts/config.sh
-          ~/work/.github/scripts/toolchain/create-gcc-summary.sh "${{ env.TAG }}" >> \
-            $ARTIFACT_PATH/gcc-tests-${{ env.TAG }}/summary.txt
-
-      - name: Present summary
-        shell: powershell
-        run: |
-          cat ${{ steps.get-wsl-paths.outputs.artifact-path }}\gcc-tests-${{ env.TAG }}\summary.txt >> $env:GITHUB_STEP_SUMMARY
+          ~/work/.github/scripts/toolchain/create-gcc-summary.sh " \
+            ${{ steps.get-wsl-paths.outputs.artifact-path-wsl }}/gcc-tests-${{ env.TAG }}" >> \
+            ${{ steps.get-wsl-paths.outputs.artifact-path-wsl }}/gcc-tests-${{ env.TAG }}/summary.md
+          cat ${{ steps.get-wsl-paths.outputs.artifact-path-wsl }}/gcc-tests-${{ env.TAG }}/summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Group test failures
         run: |
-          ~/work/.github/scripts/toolchain/group-gcc-test-failures.sh "${{ env.TAG }}" $GITHUB_STEP_SUMMARY
+          ~/work/.github/scripts/toolchain/group-gcc-test-failures.sh "gcc-tests-${{ env.TAG }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload build folder
         if: failure()
@@ -160,11 +158,11 @@ jobs:
         with:
           name: build
           retention-days: 1
-          path: ${{ steps.get-wsl-paths.outputs.build-path }}
+          path: ${{ steps.get-wsl-paths.outputs.build-path-win }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: gcc-tests-${{ env.TAG }}
-          path: ${{ steps.get-wsl-paths.outputs.artifact-path }}\gcc-tests-${{ env.TAG }}
+          path: ${{ steps.get-wsl-paths.outputs.artifact-path-win }}\gcc-tests-${{ env.TAG }}
           retention-days: 30


### PR DESCRIPTION
This allows re-using the scripts in https://github.com/Windows-on-ARM-Experiments/msys2-woarm64-build/pull/15.

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10697695783