### PR TITLE
Fix how source code repositories branches are specified

### DIFF
--- a/.github/scripts/config.sh
+++ b/.github/scripts/config.sh
@@ -4,6 +4,13 @@ set -e # exit on error
 set -x # echo on
 set -o pipefail # fail of any command in pipeline is an error
 
+BINUTILS_BRANCH=${BINUTILS_BRANCH:-woarm64}
+GCC_BRANCH=${GCC_BRANCH:-woarm64}
+MINGW_BRANCH=${MINGW_BRANCH:-woarm64}
+CYGWIN_BRANCH=${CYGWIN_BRANCH:-main}
+CYGWIN_PACKAGES_BRANCH=${CYGWIN_PACKAGES_BRANCH:-main}
+COCOM_BRANCH=${COCOM_BRANCH:-master}
+
 ARCH=${ARCH:-aarch64}
 PLATFORM=${PLATFORM:-w64-mingw32}
 if [[ "$PLATFORM" =~ (mingw|cygwin) ]]; then

--- a/.github/scripts/update-sources.sh
+++ b/.github/scripts/update-sources.sh
@@ -30,13 +30,13 @@ echo "::group::Update source code repositories"
     mkdir -p "$SOURCE_PATH"
 
     cd "$SOURCE_PATH"
-    update_repository binutils https://github.com/Windows-on-ARM-Experiments/binutils-woarm64.git woarm64
-    update_repository gcc https://github.com/Windows-on-ARM-Experiments/gcc-woarm64.git woarm64
-    update_repository mingw https://github.com/Windows-on-ARM-Experiments/mingw-woarm64.git woarm64
+    update_repository binutils https://github.com/Windows-on-ARM-Experiments/binutils-woarm64.git $BINUTILS_BRANCH
+    update_repository gcc https://github.com/Windows-on-ARM-Experiments/gcc-woarm64.git $GCC_BRANCH
+    update_repository mingw https://github.com/Windows-on-ARM-Experiments/mingw-woarm64.git $MINGW_BRANCH
     if [[ "$PLATFORM" =~ cygwin ]]; then 
-        update_repository cygwin https://github.com/Windows-on-ARM-Experiments/newlib-cygwin.git main
-        update_repository cygwin-packages https://github.com/Windows-on-ARM-Experiments/cygwin-packages.git main
-        update_repository cocom https://git.code.sf.net/p/cocom/git master
+        update_repository cygwin https://github.com/Windows-on-ARM-Experiments/newlib-cygwin.git $CYGWIN_BRANCH
+        update_repository cygwin-packages https://github.com/Windows-on-ARM-Experiments/cygwin-packages.git $CYGWIN_PACKAGES_BRANCH
+        update_repository cocom https://git.code.sf.net/p/cocom/git $COCOM_BRANCH
     fi
 echo "::endgroup::"
 


### PR DESCRIPTION
Passing the branches parameters is not working for [https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/workflows/test-toolchain.yml](https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/workflows/test-toolchain.yml) workflow. This PR fixes that.

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/10816924634/job/30009164947.