### PR TITLE
Fix switch to another git branch

### DIFF
--- a/.github/scripts/update-sources.sh
+++ b/.github/scripts/update-sources.sh
@@ -17,6 +17,10 @@ function update_repository() {
         pushd $DIRECTORY
             if [[ "$RESET_SOURCES" = 1 ]]; then
                 git reset --hard HEAD
+                if ! git show-ref --verify --quiet refs/remotes/origin/$BRANCH; then
+                    git remote set-branches --add origin $BRANCH
+                    git fetch origin --prune
+                fi
                 git switch $BRANCH
                 git clean -fdx
             fi


### PR DESCRIPTION
Since `.github/scripts/update-sources.sh` is doing `--single-branch` clone, switching to any other branch fails as the other branch do no exists locally. This PR check whether the branch exsits and adds it to the local index before actual switch.