### PR TITLE
WIP: Fix missing rebuild of all MinGW libraries

### DIFF
--- a/.github/scripts/toolchain/build-mingw.sh
+++ b/.github/scripts/toolchain/build-mingw.sh
@@ -62,6 +62,7 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_BUILD_PATH/Makefile" ]]; then
             --host=$TARGET \
             --enable-static \
             --enable-shared \
+            --with-libraries=all \
             $HOST_OPTIONS \
             $TARGET_OPTIONS \
             CFLAGS="$CFLAGS"


### PR DESCRIPTION
The current [.github/scripts/toolchain/build-mingw.sh](https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/compare/main...fix-mingw-build#diff-1f9e39124df250a620ea715c65f4c6d7ac0e0644cd15f897472d5860fe832c4f) actually do not re-build MinGW libraries, e.g. \`libwinpthreads\`.