### PR TITLE
Fix enabling debug build for MinGW

### DIFF
--- a/.github/scripts/toolchain/build-mingw-crt.sh
+++ b/.github/scripts/toolchain/build-mingw-crt.sh
@@ -12,8 +12,8 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_BUILD_PATH/Makefile" ]]; then
         rm -rf $MINGW_BUILD_PATH/*
 
         if [[ "$DEBUG" = 1 ]]; then
-            HOST_OPTIONS="$HOST_OPTIONS \
-                --enable-debug"
+            CFLAGS="$CFLAGS -O0 -ggdb"
+            CXXFLAGS="$CXXFLAGS -O0 -ggdb"
         fi
 
         case "$ARCH" in

--- a/.github/scripts/toolchain/build-mingw-winpthreads.sh
+++ b/.github/scripts/toolchain/build-mingw-winpthreads.sh
@@ -12,9 +12,10 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_BUILD_PATH/Makefile" ]]; then
         rm -rf $MINGW_BUILD_PATH/*
 
         if [[ "$DEBUG" = 1 ]]; then
-            HOST_OPTIONS="$HOST_OPTIONS \
-                --enable-debug"
+            CFLAGS="$CFLAGS -O0 -ggdb"
+            CXXFLAGS="$CXXFLAGS -O0 -ggdb"
         fi
+
 
         $SOURCE_PATH/mingw/mingw-w64-libraries/winpthreads/configure \
             --prefix=$TOOLCHAIN_PATH/$TARGET \

--- a/.github/scripts/toolchain/build-mingw.sh
+++ b/.github/scripts/toolchain/build-mingw.sh
@@ -12,8 +12,8 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_BUILD_PATH/Makefile" ]]; then
         rm -rf $MINGW_BUILD_PATH/*
 
         if [[ "$DEBUG" = 1 ]]; then
-            HOST_OPTIONS="$HOST_OPTIONS \
-                --enable-debug"
+            CFLAGS="$CFLAGS -O0 -ggdb"
+            CXXFLAGS="$CXXFLAGS -O0 -ggdb"
         fi
 
         case "$ARCH" in


### PR DESCRIPTION
There does not seem to be `--enable-debug` option in the MinGW build scripts.