### PR TITLE
Add script for finding build regression using `git bisect`

### DIFF
--- a/tools/find-regression-run.sh
+++ b/tools/find-regression-run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../.github/scripts/config.sh
+
+BRANCH=$1
+
+COMMIT=$(git rev-parse HEAD)
+git cherry-pick $(git merge-base $BRANCH HEAD)..$BRANCH
+
+set +e
+    RUN_BOOTSTRAP=0 \
+    UPDATE_SOURCES=0 \
+    RESET_SOURCES=1 \
+    APPLY_PATCHES=1 \
+      $ROOT_PATH/.github/scripts/build.sh
+    RESULT=$?
+set -e
+
+git reset --hard $COMMIT
+
+if [[ $RESULT -eq 0 ]]; then
+    echo 'Success!'
+else
+    echo 'Failure!'
+fi
+
+exit $RESULT

--- a/tools/find-regression.sh
+++ b/tools/find-regression.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../.github/scripts/config.sh
+
+REPOSITORY=$1
+REGRESSION_COMMIT=origin/rebase-upstream
+STABLE_COMMIT=origin/woarm64
+FEATURE_BRANCH=origin/woarm64
+
+pushd $SOURCE_PATH/$REPOSITORY
+    git bisect start
+    git bisect bad $REGRESSION_COMMIT
+    git checkout --detach $(git merge-base $STABLE_COMMIT HEAD)
+    git bisect good
+    git bisect run $ROOT_PATH/tools/find-regression-run.sh $FEATURE_BRANCH
+    git bisect log
+popd
+
+echo 'Success!'


### PR DESCRIPTION
So far this script is intended to be run manually:

```
tools/find-regression.sh gcc
```

with repository name as a single argument.

In the future, this can be extended to find regression in all the repositories (binutils, GCC, MinGW, Cygwin) and triggered automatically when daily updates workflow encounters build failure.