### PR TITLE
Fix release after `advanced.yml` was refactored to build runtime package

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -377,7 +377,9 @@ jobs:
 
     outputs:
       toolchain-package-name: ${{ env.PACK_TOOLCHAIN == 'true' && env.TOOLCHAIN_PACKAGE_NAME || '' }}
+      toolchain-artifact-name: ${{ env.PACK_TOOLCHAIN == 'true' && env.TOOLCHAIN_ARTIFACT_NAME || '' }}
       runtime-package-name: ${{ env.PACK_TOOLCHAIN == 'true' && env.RUNTIME_PACKAGE_NAME || '' }}
+      runtime-artifact-name: ${{ env.PACK_TOOLCHAIN == 'true' && env.RUNTIME_ARTIFACT_NAME || '' }}
       toolchain-cache-key: ${{ env.PACK_TOOLCHAIN == 'true' && steps.cache-keys.outputs.toolchain-cache-key || '' }}
       runtime-cache-key: ${{ env.PACK_TOOLCHAIN == 'true' && steps.cache-keys.outputs.runtime-cache-key || '' }}
 

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -247,10 +247,15 @@ jobs:
       url: ${{steps.create-release.outputs.url }}
 
     steps:
-      - name: Download artifact
+      - name: Download toolchain artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.build.outputs.toolchain-package-name }}
+          name: ${{ needs.build.outputs.toolchain-artifact-name }}
+
+      - name: Download runtime artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.runtime-artifact-name }}
 
       - name: Create tag
         run: |
@@ -258,7 +263,9 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          files: ${{ needs.build.outputs.toolchain-package-name }}
+          files: |
+            ${{ needs.build.outputs.toolchain-package-name }}
+            ${{ needs.build.outputs.runtime-package-name }}
           tag_name: ${{ env.TAG }}


### PR DESCRIPTION
This change was forgotten when https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/pull/204 has been done.

Tested by https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/actions/runs/12182962755 (the release was already deleted)