### PR TITLE
Add posibility to rebase feature branches to development branches to `update-sources.sh`

### DIFF
--- a/.github/scripts/config.sh
+++ b/.github/scripts/config.sh
@@ -4,6 +4,7 @@ set -e # exit on error
 set -x # echo on
 set -o pipefail # fail of any command in pipeline is an error
 
+# Branches that will be used for build when UPDATE_SOURCES=1.
 BINUTILS_REPO=${BINUTILS_REPO:-Windows-on-ARM-Experiments/binutils-woarm64}
 BINUTILS_BRANCH=${BINUTILS_BRANCH:-woarm64}
 
@@ -21,6 +22,14 @@ CYGWIN_PACKAGES_BRANCH=${CYGWIN_PACKAGES_BRANCH:-main}
 
 COCOM_REPO=${COCOM_REPO:-https://git.code.sf.net/p/cocom/git}
 COCOM_BRANCH=${COCOM_BRANCH:-master}
+
+# Baseline branches used for rebase when REBASE_SOURCES=1.
+BINUTILS_BASE_BRANCH=woarm64
+GCC_BASE_BRANCH=woarm64
+MINGW_BASE_BRANCH=woarm64
+CYGWIN_BASE_BRANCH=main
+CYGWIN_PACKAGES_BASE_BRANCH=main
+COCOM_BASE_BRANCH=master
 
 ARCH=${ARCH:-aarch64}
 PLATFORM=${PLATFORM:-w64-mingw32}
@@ -102,6 +111,9 @@ UPDATE_SOURCES=${UPDATE_SOURCES:-0} # Update source code repositories.
 UPDATE_LIBRARIES=${UPDATE_LIBRARIES:-0} # Update also source code of tested libraries repositories.
 FLAT_CLONE=${FLAT_CLONE:-1} # Whether the clone of source codes should be full or flat.
 RESET_SOURCES=${RESET_SOURCES:-0} # Reset source code repositories before update.
+REBASE_SOURCES=${REBASE_SOURCES:-0} # Together with the update, rebase repositories
+                                    # to the baseline branches and push the result.
+                                    # Unsupported when FLAT_CLONE=1.
 APPLY_PATCHES=${APPLY_PATCHES:-1} # Patch source repositories for targets requiring it.
 RUN_CONFIG=${RUN_CONFIG:-1} # Run configuration step.
 RUN_INSTALL=${RUN_INSTALL:-1} # Run installation step.


### PR DESCRIPTION
If `REBASE_SOURCES` is set to `1` in `config.sh` the `update-sources.sh` can be used to rebase feature branches of the dependencies repositories to their corresponding development branches. This is handy for keeping PRs like https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/pull/123 up-to-date on a daily basis.