### PR TITLE
Change Cocom repo URL

### DIFF
--- a/.github/scripts/config.sh
+++ b/.github/scripts/config.sh
@@ -20,7 +20,7 @@ CYGWIN_BRANCH=${CYGWIN_BRANCH:-main}
 CYGWIN_PACKAGES_REPO=${CYGWIN_PACKAGES_REPO:-Windows-on-ARM-Experiments/cygwin-packages}
 CYGWIN_PACKAGES_BRANCH=${CYGWIN_PACKAGES_BRANCH:-main}
 
-COCOM_REPO=${COCOM_REPO:-https://git.code.sf.net/p/cocom/git}
+COCOM_REPO=${COCOM_REPO:-git://git.code.sf.net/p/cocom/git}
 COCOM_BRANCH=${COCOM_BRANCH:-master}
 
 # Baseline branches used for rebase when REBASE_SOURCES=1.

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -83,7 +83,7 @@ env:
   CYGWIN_PACKAGES_REPO: Windows-on-ARM-Experiments/cygwin-packages
   CYGWIN_PACKAGES_BRANCH: ${{ inputs.cygwin_packages_branch || 'main' }}
 
-  COCOM_REPO: https://git.code.sf.net/p/cocom/git
+  COCOM_REPO: git://git.code.sf.net/p/cocom/git
   COCOM_BRANCH: ${{ inputs.cocom_branch || 'master' }}
 
   OPENBLAS_REPO: OpenMathLib/OpenBLAS


### PR DESCRIPTION
Cocom started failing in all CI runs.
 
Run cd /home/runner/work/mingw-woarm64-build/mingw-woarm64-build/code
Cloning into 'cocom'...
fatal: unable to access 'https://git.code.sf.net/p/cocom/git/': server certificate verification failed. CAfile: none CRLfile: none