### PR TITLE
Use same key (pattern) for saving and restoring the ccache cache

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -334,7 +334,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.CCACHE_DIR_PATH }}
-          key: ccache-${{ steps.cache-keys.outputs.ccache-key }}
+          key: ${{ steps.cache-keys.outputs.ccache-key }}
 
       - name: Pack toolchain
         if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && env.PACK_TOOLCHAIN == 'true' }}


### PR DESCRIPTION
The ccache cache is saved with the key `ccache-${{ steps.cache-keys.outputs.ccache-key }}` in the "Save Ccache" step. However, it is attempted to load that cache using the key `${{ steps.cache-keys.outputs.ccache-key }}` (and the restore-key `${{ steps.cache-keys.outputs.ccache-restore-keys }}`) in the "Restore Ccache" step. So they never match, and the cache for ccache is never restored.

Avoid that by using the same key in the "Save Ccache" step that is being used in the "Restore Ccache" step.