### PR TITLE
Add script for Cygwin testing

### DIFF
--- a/.github/scripts/toolchain/build-mingw-crt.sh
+++ b/.github/scripts/toolchain/build-mingw-crt.sh
@@ -91,6 +91,7 @@ if [[ "$RUN_INSTALL" = 1 ]]; then
                     ln -fs w32api/libdbghelp.a .
                     ln -fs w32api/libonecore.a .
                     ln -fs w32api/libpdh.a .
+                    ln -fs w32api/libwinmm.a .
                 popd
                 ;;
         esac

--- a/.github/scripts/toolchain/execute-cygwin-tests.sh
+++ b/.github/scripts/toolchain/execute-cygwin-tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../config.sh
+
+CYGWIN_SOURCE_PATH=$SOURCE_PATH/cygwin
+CYGWIN_BUILD_PATH=$BUILD_PATH/cygwin
+CYGWIN_WINSUP_TEST_PATH=$BUILD_PATH/cygwin/$ARCH-$PLATFORM/winsup/testsuite
+
+echo "::group::Execute Cygwin tests"
+    pushd "$CYGWIN_WINSUP_TEST_PATH" || exit 1
+        make $CHECK_MAKE_OPTIONS check
+    popd
+echo "::endgroup::"
+
+echo 'Success!'


### PR DESCRIPTION
This PR introduces a new script, `cygwin-test-suite.sh`, to build and run the internal test suite present in the `Cygwin winsup` directory. 

- Added `cygwin-test-suite.sh` to build & execute the test suite.
- Updated build.sh to conditionally invoke the test suite when `CYGWIN_TESTSUITE=1` and platform is set to Cygwin.
- Introduced `CYGWIN_TESTSUITE` configuration variable in config.sh (default: enabled).