### PR TITLE
Remove configure options that are no longer needed to build Cygwin binutils

### DIFF
--- a/.github/scripts/binutils/build.sh
+++ b/.github/scripts/binutils/build.sh
@@ -43,16 +43,6 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$BINUTILS_BUILD_PATH/Makefile" ]]; then
                 ;;
         esac
 
-        case "$ARCH-$PLATFORM" in
-            aarch64-*cygwin*)
-                # ADDED: --enable-targets=aarch64-pep
-                # ADDED: --disable-sim
-                TARGET_OPTIONS="$TARGET_OPTIONS \
-                    --enable-targets=aarch64-pep \
-                    --disable-sim"
-                ;;
-        esac
-
         $SOURCE_PATH/binutils/configure \
             --prefix=$TOOLCHAIN_PATH \
             --build=$BUILD \


### PR DESCRIPTION
Removes configure options of binutils that were added compared to the upstream recipes as workarounds to build `aarch64-pc-cygwin` target binutils that no longer seems to be needed. Removal of `--disable-sim` requires and validates https://github.com/Windows-on-ARM-Experiments/binutils-woarm64/pull/8.