### PR TITLE
Disable shared libraries build for `aarch64-pc-cygwin` target binutils

### DIFF
--- a/.github/scripts/binutils/build.sh
+++ b/.github/scripts/binutils/build.sh
@@ -18,9 +18,13 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$BINUTILS_BUILD_PATH/Makefile" ]]; then
 
         case "$PLATFORM" in
             *cygwin*)
+                # Compared to the upstream recipe:
+                #   ADDED: --with-sysroot to avoid using the host sysroot.
+                #   CHANGED: --enable-shared to --disable-shared to allow easier transfer
+                #            the produced host binaries across different build environments.
                 TARGET_OPTIONS="$TARGET_OPTIONS \
                     --enable-static \
-                    --enable-shared \
+                    --disable-shared \
                     --enable-host-shared \
                     --enable-install-libiberty \
                     --with-sysroot=$TOOLCHAIN_PATH \


### PR DESCRIPTION
This allows easier transfer of the toolchain between different build environments for `aarch64-pc-cygwin` target. The `aarch64-w64-mingw32` builds binutils with static libraries already. For example, without this change, when the toolchain is built on `ubuntu-22.04-arm` runner and then transferred to Arm64 WSL with Ubuntu-22.04, `$TOOLCHAIN_PATH/$HOST/$TARGET/lib` needs to be added to `LD_LIBRARY_PATH`.