### PR TITLE
Fix build of COCOM with GCC15

### DIFF
--- a/.github/scripts/toolchain/build-cocom.sh
+++ b/.github/scripts/toolchain/build-cocom.sh
@@ -12,6 +12,8 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$COCOM_BUILD_PATH/Makefile" ]]; then
     echo "::group::Configure COCOM"
         rm -rf $COCOM_BUILD_PATH/*
 
+        # Use the GNU89 standard to maintain compatibility with GCC15.
+        CFLAGS="$CFLAGS -std=gnu89" \
         $COCOM_SOURCE_PATH/configure \
             --prefix=$TOOLCHAIN_PATH \
             --build=$HOST \


### PR DESCRIPTION
COCOM codebase is not compatible with GCC15 as it uses partical declarations. This PR forces GNU89 standard for COCOM build. It's needed for build of Cygwin x64 -> Cygwin Arm64 cross-compiler in Cygwin shell.