### PR TITLE
Enable `cygserver` for stage 2 build

### DIFF
--- a/.github/scripts/toolchain/build-cygwin.sh
+++ b/.github/scripts/toolchain/build-cygwin.sh
@@ -22,6 +22,11 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$CYGWIN_BUILD_PATH/Makefile" ]]; then
         (cd $CYGWIN_SOURCE_PATH/winsup && ./autogen.sh)
         if [[ "$STAGE" = "1" ]]; then
             (cd $CYGWIN_SOURCE_PATH && patch -p1 -i $PATCHES_PATH/cygwin/0001-fix-autogen.patch)
+            HOST_OPTIONS="$HOST_OPTIONS \
+                --disable-cygserver"
+        else
+            HOST_OPTIONS="$HOST_OPTIONS \
+                --enable-cygserver"
         fi
 
         # ADDED: --disable-doc


### PR DESCRIPTION
Requires and tests Windows-on-ARM-Experiments/newlib-cygwin#21.