### PR TITLE
Fix Cygwin toolchain build to be compatible with upstream workflow

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -51,7 +51,7 @@ fi
 
 $ROOT_PATH/.github/scripts/toolchain/build-gcc.sh
 
-if [[ "$PLATFORM" =~ (mingw|cygwin) ]]; then
+if [[ "$PLATFORM" =~ mingw ]]; then
     $ROOT_PATH/.github/scripts/toolchain/build-mingw.sh
 fi
 if [[ "$PLATFORM" =~ cygwin ]]; then

--- a/.github/scripts/toolchain/build-mingw-headers.sh
+++ b/.github/scripts/toolchain/build-mingw-headers.sh
@@ -21,19 +21,15 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_HEADERS_BUILD_PATH/Makefile" ]]; t
                 TARGET_OPTIONS="$TARGET_OPTIONS \
                     --enable-w32api"
                 ;;
-            *mingw*)
-                TARGET_OPTIONS="$TARGET_OPTIONS \
-                    --enable-sdk=all"
-                ;;
         esac
 
-        case "$CRT" in
-            ucrt)
+        case "$PLATFORM-$CRT" in
+            *mingw*-ucrt)
                 TARGET_OPTIONS="$TARGET_OPTIONS \
                     --with-default-win32-winnt=0x603 \
                     --with-default-msvcrt=ucrt"
             ;;
-            msvcrt)
+            *mingw*-msvcrt)
                 TARGET_OPTIONS="$TARGET_OPTIONS \
                     --with-default-win32-winnt=0x601 \
                     --with-default-msvcrt=msvcrt"
@@ -44,6 +40,7 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$MINGW_HEADERS_BUILD_PATH/Makefile" ]]; t
             --prefix=$TOOLCHAIN_PATH/$TARGET \
             --build=$BUILD \
             --host=$TARGET \
+            --enable-sdk=all \
             $HOST_OPTIONS \
             $TARGET_OPTIONS
     echo "::endgroup::"

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -320,7 +320,7 @@ jobs:
           .github/scripts/toolchain/build-gcc.sh
 
       - name: Build MinGW
-        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && matrix.platform != 'pc-linux-gnu' }}
+        if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' && matrix.platform == 'w64-mingw32' }}
         run: |
           .github/scripts/toolchain/build-mingw.sh
 


### PR DESCRIPTION
Fix Cygwin toolchain build to be compatible with upstream workflow.

Based on https://cygwin.com/cgit/cygwin-packages/w32api-headers/tree/w32api-headers.cygport

Requires https://github.com/Windows-on-ARM-Experiments/newlib-cygwin/pull/29