### PR TITLE
Use `--disable-utils` for stage1 Cygwin build

### DIFF
--- a/.github/scripts/toolchain/build-cygwin.sh
+++ b/.github/scripts/toolchain/build-cygwin.sh
@@ -23,10 +23,12 @@ if [[ "$RUN_CONFIG" = 1 ]] || [[ ! -f "$CYGWIN_BUILD_PATH/Makefile" ]]; then
         if [[ "$STAGE" = "1" ]]; then
             (cd $CYGWIN_SOURCE_PATH && patch -p1 -i $PATCHES_PATH/cygwin/0001-fix-autogen.patch)
             HOST_OPTIONS="$HOST_OPTIONS \
-                --disable-cygserver"
+                --disable-cygserver \
+                --disable-utils"
         else
             HOST_OPTIONS="$HOST_OPTIONS \
-                --enable-cygserver"
+                --enable-cygserver \
+                --enable-utils"
         fi
 
         # ADDED: --disable-doc


### PR DESCRIPTION
Workaround removing build of `utils` in Cygwin codebase was removed with `--disable-utils` `configure` option.