### PR TITLE
Change way to fetch processor architecture

### DIFF
--- a/.github/scripts/config.sh
+++ b/.github/scripts/config.sh
@@ -39,7 +39,7 @@ else
     CRT=${CRT:-libc}
 fi
 
-PROCESSOR=$(uname --processor)
+PROCESSOR=$(uname --machine)
 BUILD=${BUILD:-$PROCESSOR-pc-linux-gnu}
 HOST=${HOST:-$PROCESSOR-pc-linux-gnu}
 TARGET=$ARCH-$PLATFORM


### PR DESCRIPTION
Debian does not support `uname --processor` to fetch the processor architecture. Using `--machine` is a more universal approach.